### PR TITLE
fix: breaking release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ vendor/divido/.DS_Store
 .vscode/
 wpcs/
 vendor/
-composer.lock

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,617 @@
+{
+  "_readme": [
+    "This file locks the dependencies of your project to a known state",
+    "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+    "This file is @generated automatically"
+  ],
+  "content-hash": "c4ce35cde3c72de37b6e1d1c20bfc91c",
+  "packages": [
+    {
+      "name": "divido/merchant-sdk",
+      "version": "v2.1.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/dividohq/merchant-api-pub-sdk-php.git",
+        "reference": "631984231ebc5606187eb40ec446256651b79dcf"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/dividohq/merchant-api-pub-sdk-php/zipball/631984231ebc5606187eb40ec446256651b79dcf",
+        "reference": "631984231ebc5606187eb40ec446256651b79dcf",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=5.6",
+        "psr/http-message": "^1.0",
+        "psr/log": "^1"
+      },
+      "require-dev": {
+        "guzzlehttp/guzzle": "^6.3",
+        "hamcrest/hamcrest-php": "^2.0",
+        "kint-php/kint": "^2.1",
+        "mockery/mockery": "1.1.0",
+        "phpdocumentor/phpdocumentor": "2.9.0",
+        "phpdocumentor/reflection-docblock": "~2.0",
+        "phpunit/phpunit": "^5"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Divido\\MerchantSDK\\": "lib/"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "authors": [
+        {
+          "name": "Neil McGibbon",
+          "email": "code@neilmcgibbon.com"
+        }
+      ],
+      "time": "2019-04-01T15:30:39+00:00"
+    },
+    {
+      "name": "divido/merchant-sdk-guzzle-6",
+      "version": "dev-master",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/dividohq/merchant-api-pub-sdk-php-guzzle6.git",
+        "reference": "64911e676c6d63b155e296974922cef46925759d"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/dividohq/merchant-api-pub-sdk-php-guzzle6/zipball/64911e676c6d63b155e296974922cef46925759d",
+        "reference": "64911e676c6d63b155e296974922cef46925759d",
+        "shasum": ""
+      },
+      "require": {
+        "divido/merchant-sdk": "^2",
+        "guzzlehttp/guzzle": "^6.2",
+        "php": ">=5.6"
+      },
+      "require-dev": {
+        "mockery/mockery": "1.1.0",
+        "phpunit/phpunit": "^5"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Divido\\MerchantSDKGuzzle6\\": "lib/"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "authors": [
+        {
+          "name": "Neil McGibbon",
+          "email": "code@neilmcgibbon.com"
+        },
+        {
+          "name": "Mike Lovely",
+          "email": "mike.lovely@divido.com"
+        }
+      ],
+      "time": "2019-02-19T15:59:54+00:00"
+    },
+    {
+      "name": "guzzlehttp/guzzle",
+      "version": "6.5.5",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/guzzle/guzzle.git",
+        "reference": "9d4290de1cfd701f38099ef7e183b64b4b7b0c5e"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/guzzle/guzzle/zipball/9d4290de1cfd701f38099ef7e183b64b4b7b0c5e",
+        "reference": "9d4290de1cfd701f38099ef7e183b64b4b7b0c5e",
+        "shasum": ""
+      },
+      "require": {
+        "ext-json": "*",
+        "guzzlehttp/promises": "^1.0",
+        "guzzlehttp/psr7": "^1.6.1",
+        "php": ">=5.5",
+        "symfony/polyfill-intl-idn": "^1.17.0"
+      },
+      "require-dev": {
+        "ext-curl": "*",
+        "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
+        "psr/log": "^1.1"
+      },
+      "suggest": {
+        "psr/log": "Required for using the Log middleware"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "6.5-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "GuzzleHttp\\": "src/"
+        },
+        "files": [
+          "src/functions_include.php"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Michael Dowling",
+          "email": "mtdowling@gmail.com",
+          "homepage": "https://github.com/mtdowling"
+        }
+      ],
+      "description": "Guzzle is a PHP HTTP client library",
+      "homepage": "http://guzzlephp.org/",
+      "keywords": [
+        "client",
+        "curl",
+        "framework",
+        "http",
+        "http client",
+        "rest",
+        "web service"
+      ],
+      "time": "2020-06-16T21:01:06+00:00"
+    },
+    {
+      "name": "guzzlehttp/promises",
+      "version": "v1.3.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/guzzle/promises.git",
+        "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+        "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=5.5.0"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^4.0"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.4-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "GuzzleHttp\\Promise\\": "src/"
+        },
+        "files": [
+          "src/functions_include.php"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Michael Dowling",
+          "email": "mtdowling@gmail.com",
+          "homepage": "https://github.com/mtdowling"
+        }
+      ],
+      "description": "Guzzle promises library",
+      "keywords": [
+        "promise"
+      ],
+      "time": "2016-12-20T10:07:11+00:00"
+    },
+    {
+      "name": "guzzlehttp/psr7",
+      "version": "1.6.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/guzzle/psr7.git",
+        "reference": "239400de7a173fe9901b9ac7c06497751f00727a"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/guzzle/psr7/zipball/239400de7a173fe9901b9ac7c06497751f00727a",
+        "reference": "239400de7a173fe9901b9ac7c06497751f00727a",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=5.4.0",
+        "psr/http-message": "~1.0",
+        "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
+      },
+      "provide": {
+        "psr/http-message-implementation": "1.0"
+      },
+      "require-dev": {
+        "ext-zlib": "*",
+        "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
+      },
+      "suggest": {
+        "zendframework/zend-httphandlerrunner": "Emit PSR-7 responses"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.6-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "GuzzleHttp\\Psr7\\": "src/"
+        },
+        "files": [
+          "src/functions_include.php"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Michael Dowling",
+          "email": "mtdowling@gmail.com",
+          "homepage": "https://github.com/mtdowling"
+        },
+        {
+          "name": "Tobias Schultze",
+          "homepage": "https://github.com/Tobion"
+        }
+      ],
+      "description": "PSR-7 message implementation that also provides common utility methods",
+      "keywords": [
+        "http",
+        "message",
+        "psr-7",
+        "request",
+        "response",
+        "stream",
+        "uri",
+        "url"
+      ],
+      "time": "2019-07-01T23:21:34+00:00"
+    },
+    {
+      "name": "psr/http-message",
+      "version": "1.0.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/php-fig/http-message.git",
+        "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+        "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=5.3.0"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.0.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Psr\\Http\\Message\\": "src/"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "PHP-FIG",
+          "homepage": "http://www.php-fig.org/"
+        }
+      ],
+      "description": "Common interface for HTTP messages",
+      "homepage": "https://github.com/php-fig/http-message",
+      "keywords": [
+        "http",
+        "http-message",
+        "psr",
+        "psr-7",
+        "request",
+        "response"
+      ],
+      "time": "2016-08-06T14:39:51+00:00"
+    },
+    {
+      "name": "psr/log",
+      "version": "1.1.3",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/php-fig/log.git",
+        "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
+        "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=5.3.0"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.1.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Psr\\Log\\": "Psr/Log/"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "PHP-FIG",
+          "homepage": "http://www.php-fig.org/"
+        }
+      ],
+      "description": "Common interface for logging libraries",
+      "homepage": "https://github.com/php-fig/log",
+      "keywords": [
+        "log",
+        "psr",
+        "psr-3"
+      ],
+      "time": "2020-03-23T09:12:05+00:00"
+    },
+    {
+      "name": "ralouphie/getallheaders",
+      "version": "3.0.3",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/ralouphie/getallheaders.git",
+        "reference": "120b605dfeb996808c31b6477290a714d356e822"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+        "reference": "120b605dfeb996808c31b6477290a714d356e822",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=5.6"
+      },
+      "require-dev": {
+        "php-coveralls/php-coveralls": "^2.1",
+        "phpunit/phpunit": "^5 || ^6.5"
+      },
+      "type": "library",
+      "autoload": {
+        "files": [
+          "src/getallheaders.php"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Ralph Khattar",
+          "email": "ralph.khattar@gmail.com"
+        }
+      ],
+      "description": "A polyfill for getallheaders.",
+      "time": "2019-03-08T08:55:37+00:00"
+    },
+    {
+      "name": "symfony/polyfill-intl-idn",
+      "version": "v1.17.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/symfony/polyfill-intl-idn.git",
+        "reference": "a57f8161502549a742a63c09f0a604997bf47027"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/a57f8161502549a742a63c09f0a604997bf47027",
+        "reference": "a57f8161502549a742a63c09f0a604997bf47027",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=5.3.3",
+        "symfony/polyfill-mbstring": "^1.3",
+        "symfony/polyfill-php72": "^1.10"
+      },
+      "suggest": {
+        "ext-intl": "For best performance"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.17-dev"
+        },
+        "thanks": {
+          "name": "symfony/polyfill",
+          "url": "https://github.com/symfony/polyfill"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Symfony\\Polyfill\\Intl\\Idn\\": ""
+        },
+        "files": [
+          "bootstrap.php"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Laurent Bassin",
+          "email": "laurent@bassin.info"
+        },
+        {
+          "name": "Symfony Community",
+          "homepage": "https://symfony.com/contributors"
+        }
+      ],
+      "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+      "homepage": "https://symfony.com",
+      "keywords": [
+        "compatibility",
+        "idn",
+        "intl",
+        "polyfill",
+        "portable",
+        "shim"
+      ],
+      "time": "2020-06-06T08:46:27+00:00"
+    },
+    {
+      "name": "symfony/polyfill-mbstring",
+      "version": "v1.17.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/symfony/polyfill-mbstring.git",
+        "reference": "7110338d81ce1cbc3e273136e4574663627037a7"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7110338d81ce1cbc3e273136e4574663627037a7",
+        "reference": "7110338d81ce1cbc3e273136e4574663627037a7",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=5.3.3"
+      },
+      "suggest": {
+        "ext-mbstring": "For best performance"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.17-dev"
+        },
+        "thanks": {
+          "name": "symfony/polyfill",
+          "url": "https://github.com/symfony/polyfill"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Symfony\\Polyfill\\Mbstring\\": ""
+        },
+        "files": [
+          "bootstrap.php"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Nicolas Grekas",
+          "email": "p@tchwork.com"
+        },
+        {
+          "name": "Symfony Community",
+          "homepage": "https://symfony.com/contributors"
+        }
+      ],
+      "description": "Symfony polyfill for the Mbstring extension",
+      "homepage": "https://symfony.com",
+      "keywords": [
+        "compatibility",
+        "mbstring",
+        "polyfill",
+        "portable",
+        "shim"
+      ],
+      "time": "2020-06-06T08:46:27+00:00"
+    },
+    {
+      "name": "symfony/polyfill-php72",
+      "version": "v1.17.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/symfony/polyfill-php72.git",
+        "reference": "f048e612a3905f34931127360bdd2def19a5e582"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/f048e612a3905f34931127360bdd2def19a5e582",
+        "reference": "f048e612a3905f34931127360bdd2def19a5e582",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=5.3.3"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.17-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Symfony\\Polyfill\\Php72\\": ""
+        },
+        "files": [
+          "bootstrap.php"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Nicolas Grekas",
+          "email": "p@tchwork.com"
+        },
+        {
+          "name": "Symfony Community",
+          "homepage": "https://symfony.com/contributors"
+        }
+      ],
+      "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+      "homepage": "https://symfony.com",
+      "keywords": [
+        "compatibility",
+        "polyfill",
+        "portable",
+        "shim"
+      ],
+      "time": "2020-05-12T16:47:27+00:00"
+    }
+  ],
+  "packages-dev": [],
+  "aliases": [],
+  "minimum-stability": "stable",
+  "stability-flags": {
+    "divido/merchant-sdk-guzzle-6": 20
+  },
+  "prefer-stable": false,
+  "prefer-lowest": false,
+  "platform": {
+    "php": ">=5"
+  },
+  "platform-dev": []
+}


### PR DESCRIPTION
When we release a new version of the plugin we run `make release version=x.x.x` from
[https://github.com/dividohq/integrations-woocommerce/blob/master/ops/release/wp-release.sh](https://github.com/dividohq/integrations-woocommerce/blob/master/ops/release/wp-release.sh)

The basic stages of this script are:

1. clone this repo into a subfolder in [https://github.com/dividohq/integrations-woocommerce](https://github.com/dividohq/integrations-woocommerce)
2. `composer install --no-dev`
3. upload changes to svn repo http://plugins.svn.wordpress.org/finance-gateway-for-woocommerce/

The new version of the plugin is now immediately available for upgrade

Prior to this fix when `composer install --no-dev` is run there are some new composer packages added which are not contained in the previous release v2.2.2

- symfony/polyfill-intl-normalizer (v1.18.0)
- paragonie/random_compat (v9.99.99)
- symfony/polyfill-php70 (v1.18.0)

These packages are **NOT UPLOADED** to the wordpress svn <a href="http://plugins.svn.wordpress.org/finance-gateway-for-woocommerce/">repository</a> because they are blocked by pre-commit webhooks:

``
Cannot declare class ArithmeticError, because the name is already in use in Standard input code on line 5
``

When a user updates the plugin it results in the wordpress site website breaking as the packages are not found but they are expected



<img width="747" alt="Screenshot 2020-07-28 at 13 48 21" src="https://user-images.githubusercontent.com/6682271/88717740-e636e900-d118-11ea-91ff-d1088a2b8827.png">



Therefore recommend using the **composer.lock** file from the woocommerce plugin v2.2.2 release. 
All the packages here will not have upload problems