### PR TITLE
Feat fix psr7 load

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,11 @@
 {
     "require": {
         "php": ">=5",
-        "divido/merchant-sdk-guzzle-6": "dev-refactor/remove-guzzle",
+        "divido/merchant-sdk-guzzle-6": "dev-master",
         "divido/merchant-sdk": "v2.1.1"
+    },
+    "conflict": {
+        "symfony/polyfill-intl-idn": ">=1.18",
+        "symfony/polyfill-mbstring": ">1.22.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "php": ">=5",
-        "divido/merchant-sdk-guzzle-6": "dev-master",
+        "divido/merchant-sdk-guzzle-6": "dev-refactor/remove-guzzle",
         "divido/merchant-sdk": "v2.1.1"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,7 @@
 {
     "require": {
         "php": ">=5",
-        "divido/merchant-sdk-guzzle-6": "dev-refactor/remove-guzzle",
+        "divido/merchant-sdk-guzzle-6": "dev-master",
         "divido/merchant-sdk": "v2.1.1"
-    },
-    "conflict": {
-        "symfony/polyfill-intl-idn": ">=1.18"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,6 @@
     },
     "conflict": {
         "symfony/polyfill-intl-idn": ">=1.18",
-        "symfony/polyfill-mbstring": ">1.22.0"
+        "symfony/polyfill-mbstring": ">=1.22.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "php": ">=5",
-        "divido/merchant-sdk-guzzle-6": "dev-master",
+        "divido/merchant-sdk-guzzle-6": "dev-refactor/remove-guzzle",
         "divido/merchant-sdk": "v2.1.1"
     }
 }


### PR DESCRIPTION
When making a new release and uploading the code to svn there was a "pre-commit webhook error"

```
PHP error in: finance-gateway-for-woocommerce/trunk/vendor/symfony/polyfill-mbstring/bootstrap80.php:

Parse error: syntax error, unexpected '|', expecting variable (T_VARIABLE) in Standard input code on line 15
Errors parsing Standard input code
```

The svn obviously doesn't like the use of "|" character [here](https://github.com/symfony/polyfill-mbstring/blob/main/bootstrap80.php#L15) used for as a [bitwise OR](https://stackoverflow.com/questions/13811922/what-does-using-a-single-pipe-in-a-function-argument-do) in php 8 

SImilar to the issue related to this [fix ](https://github.com/dividohq/finance-plugin-woocommerce/pull/68) the conflicted versions for **symfony/polyfill-mbstring** was set at to at v1.22 and greater so v1.20 was used instead

