### PR TITLE
fix: add customisable logo

### DIFF
--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -113,9 +113,9 @@ function woocommerce_finance_init()
             $this->widget_threshold = (!empty($this->settings['widgetThreshold'])) ? $this->settings['widgetThreshold'] : 250;
             $this->secret = (!empty($this->settings['secret'])) ? $this->settings['secret'] : '';
             $this->product_select = (!empty($this->settings['productSelect'])) ? $this->settings['productSelect'] : '';
-            $this->icon = (empty($this->api_key)) ? 'https://cdn.divido.com/widget/themes/divido/logo.png' : "https://cdn.divido.com/widget/themes/". $this->get_finance_env($this->api_key) ."/logo.png";
             $this->useStoreLanguage = (!empty($this->settings['useStoreLanguage'])) ? $this->settings['useStoreLanguage'] : '';
 
+            add_filter( 'woocommerce_gateway_icon', array($this, 'custom_gateway_icon'), 10, 2 );
 
             // Load logger.
             if (version_compare(WC_VERSION, '2.7', '<')) {
@@ -171,6 +171,25 @@ function woocommerce_finance_init()
             add_shortcode('finance_widget', array($this, 'anypage_widget'));
             //Since 1.0.3
             add_filter('plugin_action_links_' . plugin_basename(__FILE__), array($this, 'finance_gateway_settings_link'));
+        }
+
+        /**
+         * @param $icon
+         * @param $id
+         * @return string
+         */
+        public function custom_gateway_icon( $icon, $id ) {
+            if ( $id === 'finance' ) {
+                if (empty($this->api_key)) {
+                    return "<img style='float:right;' src='https://cdn.divido.com/widget/themes/divido/logo.png'/>";
+                } else if ($this->get_finance_env($this->api_key) === 'nordea' ){
+                     return "<img style='height:26px;float:right;' src='https://cdn.divido.com/widget/themes/" . $this->get_finance_env($this->api_key) . "/logo.png'/>";
+                } else {
+                    return "<img style='float:right;' src='https://cdn.divido.com/widget/themes/" . $this->get_finance_env($this->api_key) . "/logo.png'/>";
+                }
+            } else {
+                return $icon;
+            }
         }
 
         /**

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -11,7 +11,7 @@ defined('ABSPATH') or die('Denied');
  * Plugin Name: Finance Payment Gateway for WooCommerce
  * Plugin URI: http://integrations.divido.com/finance-gateway-woocommerce
  * Description: The Finance Payment Gateway plugin for WooCommerce.
- * Version: 2.2.6
+ * Version: 2.2.7
  *
  * Author: Divido Financial Services Ltd
  * Author URI: www.divido.com
@@ -87,7 +87,7 @@ function woocommerce_finance_init()
          */
         function __construct()
         {
-            $this->plugin_version= '2.2.6';
+            $this->plugin_version= '2.2.7';
             add_action('init', array($this,'wpdocs_load_textdomain'));
 
             $this->id = 'finance';

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -183,7 +183,7 @@ function woocommerce_finance_init()
                 if (empty($this->api_key)) {
                     return "<img style='float:right;' src='https://cdn.divido.com/widget/themes/divido/logo.png'/>";
                 } else if ($this->get_finance_env($this->api_key) === 'nordea' ){
-                     return "<img style='height:26px;float:right;' src='https://cdn.divido.com/widget/themes/" . $this->get_finance_env($this->api_key) . "/logo.png'/>";
+                     return "<img style='height:24px;float:right;' src='https://cdn.divido.com/widget/themes/" . $this->get_finance_env($this->api_key) . "/logo.png'/>";
                 } else {
                     return "<img style='float:right;' src='https://cdn.divido.com/widget/themes/" . $this->get_finance_env($this->api_key) . "/logo.png'/>";
                 }

--- a/readme.txt
+++ b/readme.txt
@@ -6,8 +6,8 @@ Tags:              woothemes,woocommerce,payment gateway,payment,module,ecommerc
 Author URI:        integrations.divido.com
 Author:            Divido Financial Services Ltd
 Requires at least: 3.0.2
-Tested up to:      5.5.3
-Stable tag:        2.2.6
+Tested up to:      5.7.2
+Stable tag:        2.2.7
 Version:           2.2.6
 
 License: GPLv2 or later
@@ -44,6 +44,9 @@ Enable/Disable Automatic Cancellation: Allows you to select if an "Cancellation"
 
 
  == Changelog ==
+Version 2.2.7
+Chore: Float payment gateway logo to the right and increase size for Nordea
+
 Version 2.2.6
 Fix: resolves missing API key error header text issue
 


### PR DESCRIPTION
Jira ticket: https://divido.atlassian.net/browse/SCB-198

Nordea have request that their logo is larger. This method checks if the finance environment is nordea and makes it a height of 24px rather than the standard 18px high.

Found [this on Stackoverflow](https://stackoverflow.com/questions/40723517/add-an-icon-to-custom-woocommerce-payment-gateway) which seems to work.

