### PR TITLE
fix(calculator-widget): update urls for each environment

### DIFF
--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -208,7 +208,12 @@ function woocommerce_finance_init()
                 return false;
             }
             $finance = $this->get_finance_env($this->api_key);
-            wp_register_script('woocommerce-finance-gateway-calculator', '//cdn.divido.com/widget/v3/' . $finance . '.calculator.js', false, 1.0, true);
+            $environment = $this->environments($this->api_key);
+            if ($environment == 'production'){
+                wp_register_script('woocommerce-finance-gateway-calculator', '//cdn.divido.com/widget/v3/' . $finance . '.calculator.js', false, 1.0, true);
+            } else {
+                wp_register_script('woocommerce-finance-gateway-calculator', '//cdn.divido.com/widget/v3/' . $finance . '.' . $environment . '.calculator.js', false, 1.0, true);
+            }
             wp_enqueue_script('woocommerce-finance-gateway-calculator');
 
             $attributes = shortcode_atts(array(
@@ -309,7 +314,12 @@ function woocommerce_finance_init()
                 $key = preg_split('/\./', $this->api_key);
                 $protocol = (isset($_SERVER['HTTPS']) && 'on' === $_SERVER['HTTPS']) ? 'https' : 'http'; // Input var okay.
                 $finance = $this->get_finance_env($this->api_key);
-                wp_register_script('woocommerce-finance-gateway-calculator', $protocol . '://cdn.divido.com/widget/v3/' . $finance . '.calculator.js', false, 1.0, true);
+                $environment = $this->environments($this->api_key);
+                if ($environment == 'production'){
+                    wp_register_script('woocommerce-finance-gateway-calculator', $protocol . '://cdn.divido.com/widget/v3/' . $finance . '.calculator.js', false, 1.0, true);
+                } else {
+                    wp_register_script('woocommerce-finance-gateway-calculator', $protocol . '://cdn.divido.com/widget/v3/' . $finance . '.' . $environment . '.calculator.js', false, 1.0, true);
+                }
                 wp_register_script('woocoomerce-finance-gateway-calculator_price_update', plugins_url('', __FILE__) . '/js/widget_price_update.js', false, 1.0, true);
                 wp_register_style('woocommerce-finance-gateway-style', plugins_url('', __FILE__) . '/css/style.css', false, 1.0);
                 $array = array(


### PR DESCRIPTION
The calculator widget will now fetch the correct js file depending on the environment. e.g.  sandbox js file http://cdn.divido.com/widget/v3/divido.sandbox.calculator.js?ver=1