### PR TITLE
fix: [LM2-351] fix merchant sdk singleton

### DIFF
--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -154,14 +154,14 @@ function woocommerce_finance_init()
             $this->secret = (!empty($this->settings['secret'])) ? $this->settings['secret'] : '';
             $this->product_select = (!empty($this->settings['productSelect'])) ? $this->settings['productSelect'] : '';
             $this->useStoreLanguage = (!empty($this->settings['useStoreLanguage'])) ? $this->settings['useStoreLanguage'] : '';
-            // set the tenancy environment based on the user input "url" field or default it from the api key
-            $this->url = (!empty($this->settings['url'])) ? $this->settings['url'] : $this->get_default_merchant_api_pub_url($this->api_key);
             // set the environment from the api key
             try {
                 $this->environment = \Divido\MerchantSDK\Environment::getEnvironmentFromAPIKey($this->api_key);
             } catch (Exception $e) {
                 $this->environment = '';
             }
+            // set the tenancy environment based on the user input "url" field or default it from the api key
+            $this->url = (!empty($this->settings['url'])) ? $this->settings['url'] : $this->get_default_merchant_api_pub_url($this->api_key);
 
             add_filter( 'woocommerce_gateway_icon', array($this, 'custom_gateway_icon'), 10, 2 );
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "require": {
         "php": ">=5",
         "divido/merchant-sdk-guzzle-6": "dev-master",
-        "divido/merchant-sdk": "v2.2.2"
+        "divido/merchant-sdk": "v2.3.0"
     },
     "conflict": {
         "symfony/polyfill-intl-idn": ">=1.18",


### PR DESCRIPTION
We need to instantiate a new Merchant SDK class instance in all of the function calls, and so - for now - the Merchant SDK cannot be a singleton.

This needs to happen because the merchant SDK instance needs to be updated every time the api key or merchant api url changes. In theory we could then instantiate it once as a class variable in the class constructor, but this does not work because of the way errors are being handled in the code. 

@joelbitar This PR also ensures that errors thrown in the merchant SDK are handled. It follows the current error handling conventions, which are bad, but refactoring the error handling is outside the scope of this task.