### PR TITLE
chore: adds pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,3 @@
 ### PR CHECKLIST
 
-- [ ] All translations are concatenated with an EOT character between the translation context and key (ie. `backend/configgeneral_settings_header`)
+- [ ] All translations are concatenated with an EOT character between the translation context and key (ie. `backend/config[eot]general_settings_header`)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,3 @@
 ### PR CHECKLIST
 
-- [ ] All translations are concatenated with an EOT character between the translation context and key (ie. `backend/config[eot]general_settings_header`)
+- [ ] All translations are concatenated with an EOT character between the translation context and key (ie. `backend/config[EOT]general_settings_header`)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+### PR CHECKLIST
+
+- [ ] All translations are concatenated with an EOT character between the translation context and key (ie. `backend/configgeneral_settings_header`)


### PR DESCRIPTION
Adds a PR template to ensure all developers are aware of the need for an EOT character within translation references