### PR TITLE
fix: remove unnecessary parameter

### DIFF
--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -1146,7 +1146,7 @@ function woocommerce_finance_init()
          */
         function admin_options()
         {
-            $sdk = Merchant_SDK::getSDK($this->url, $this->api_key);
+            $sdk = Merchant_SDK::getSDK($this->url, 'sandbox_dummy_api.key');
             $response = $sdk->health()->checkHealth();
 
             $status_code = $response["status_code"] ?? null;

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -1146,7 +1146,13 @@ function woocommerce_finance_init()
          */
         function admin_options()
         {
+            // Sole purpose of this specific instance of the Merchant SDK is to access
+            // checkHealth() which doesn't require API key.
+            // Eliminating risk of accidental API key leakage here by not including it.
+            // Reason is that checkHealth() uses sends a request via HttpClientWrapper which: 
+            // "Adds the base URL and Merchant API Key to the request before sending."
             $sdk = Merchant_SDK::getSDK($this->url, 'sandbox_dummy_api.key');
+
             $response = $sdk->health()->checkHealth();
 
             $status_code = $response["status_code"] ?? null;

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -1147,7 +1147,7 @@ function woocommerce_finance_init()
         function admin_options()
         {
             $sdk = Merchant_SDK::getSDK($this->url, $this->api_key);
-            $response = $sdk->health()->checkHealth($this->url);
+            $response = $sdk->health()->checkHealth();
 
             $status_code = $response["status_code"] ?? null;
             $bad_host = !$status_code;

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -1146,13 +1146,7 @@ function woocommerce_finance_init()
          */
         function admin_options()
         {
-            // Sole purpose of this specific instance of the Merchant SDK is to access
-            // checkHealth() which doesn't require API key.
-            // Eliminating risk of accidental API key leakage here by not including it.
-            // Reason is that checkHealth() uses sends a request via HttpClientWrapper which: 
-            // "Adds the base URL and Merchant API Key to the request before sending."
-            $sdk = Merchant_SDK::getSDK($this->url, 'sandbox_dummy_api.key');
-
+            $sdk = Merchant_SDK::getSDK($this->url, $this->api_key);
             $response = $sdk->health()->checkHealth();
 
             $status_code = $response["status_code"] ?? null;


### PR DESCRIPTION
`checkHealth()` gets URL from the SDK instance so doesn't need it as a parameter

Also, removing API key from the SDK instance used for healthcheck to avoid leaking API key