### PR TITLE
fix: [LM2-351] fix caching environment

### DIFF
--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -1570,6 +1570,7 @@ function woocommerce_finance_init()
         {
             $sdk = Merchant_SDK::getSDK($this->url, $this->api_key);
 
+            // ensure that the url is used as a part of the cache key so the right env is returned from the cache
             $transient = 'environment' . md5($this->url);
             $setting = get_transient($transient);
 

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -1570,7 +1570,7 @@ function woocommerce_finance_init()
         {
             $sdk = Merchant_SDK::getSDK($this->url, $this->api_key);
 
-            $transient = 'environment';
+            $transient = 'environment'. md5($this->url);
             $setting = get_transient($transient);
 
             if (!empty($setting)) {

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -1570,7 +1570,7 @@ function woocommerce_finance_init()
         {
             $sdk = Merchant_SDK::getSDK($this->url, $this->api_key);
 
-            $transient = 'environment'. md5($this->url);
+            $transient = 'environment' . md5($this->url);
             $setting = get_transient($transient);
 
             if (!empty($setting)) {


### PR DESCRIPTION
This PR fixes the issue where the incorrect environment was being returned from the cache after the environments switched in the settings. It does this by hashing the url and using that as a part of the key. 
