### PR TITLE
fix/php8 compatibility nordea

### DIFF
--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -16,7 +16,7 @@ defined('ABSPATH') or die('Denied');
  * Plugin Name: Finance Payment Gateway for WooCommerce
  * Plugin URI: http://integrations.divido.com/finance-gateway-woocommerce
  * Description: The Finance Payment Gateway plugin for WooCommerce.
- * Version: 2.3.1
+ * Version: 2.3.2
  *
  * Author: Divido Financial Services Ltd
  * Author URI: www.divido.com
@@ -129,7 +129,7 @@ function woocommerce_finance_init()
          */
         function __construct()
         {
-            $this->plugin_version = '2.3.1';
+            $this->plugin_version = '2.3.2';
             add_action('init', array($this, 'wpdocs_load_textdomain'));
 
             $this->id = 'finance';

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -572,7 +572,10 @@ jQuery(document).ready(function() {
                 $priceIncludingTax = floatval($priceIncludingTax);
             }
 
-            return $priceIncludingTax * 100;
+            // Multiply by 100 to get the pence/cents value
+            $priceIncludingTax = $priceIncludingTax * 100;
+
+            return $priceIncludingTax;
         }
 
         /**

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -1,8 +1,8 @@
 <?php
 
+use Divido\MerchantSDK\Environment;
 use Divido\MerchantSDK\Exceptions\InvalidApiKeyFormatException;
 use Divido\MerchantSDK\Exceptions\InvalidEnvironmentException;
-use Divido\MerchantSDK\Environment;
 
 defined('ABSPATH') or die('Denied');
 /**
@@ -543,6 +543,8 @@ jQuery(document).ready(function() {
          * gets deprecated in 2.7, and wc_get_price_including_tax gets introduced in
          * 2.7.
          *
+         * Returns a float representing the price of this product in pence/pennies
+         *
          * @since  1.0.0
          * @param  WC_Product $product Product instance.
          * @param  array $args Args array.
@@ -559,10 +561,18 @@ jQuery(document).ready(function() {
                     )
                 );
 
-                return $product->get_price_including_tax($args['qty'], $args['price']) * 100;
+                $priceIncludingTax = $product->get_price_including_tax($args['qty'], $args['price']);
             } else {
-                return wc_get_price_including_tax($product, $args) * 100;
+                $priceIncludingTax = wc_get_price_including_tax($product, $args);
             }
+
+            // $priceIncludingTax could be a float or string
+            // Before we do math on this we need to convert the value to a float
+            if (!is_float($priceIncludingTax)) {
+                $priceIncludingTax = floatval($priceIncludingTax);
+            }
+
+            return $priceIncludingTax * 100;
         }
 
         /**

--- a/readme.txt
+++ b/readme.txt
@@ -7,8 +7,8 @@ Author URI:        integrations.divido.com
 Author:            Divido Financial Services Ltd
 Requires at least: 3.0.2
 Tested up to:      5.7.2
-Stable tag:        2.3.1
-Version:           2.3.1
+Stable tag:        2.3.2
+Version:           2.3.2
 
 License: GPLv2 or later
 
@@ -44,6 +44,9 @@ Enable/Disable Automatic Cancellation: Allows you to select if an "Cancellation"
 
 
  == Changelog ==
+Version 2.3.2
+Fix: convert product prices passed as strings to floating point variables for math operations in widget inclusion.
+
 Version 2.3.1
 Fix: Suppress errors for empty API keys in admin panel
 


### PR DESCRIPTION
### PR CHECKLIST

- [x] All translations are concatenated with an EOT character between the translation context and key (ie. `backend/config[EOT]general_settings_header`)
- [x] The version information documented in the readme.txt has been manually updated in line with semantic versioning
- [x] The version information in `class-wc-gateway-finance.php` (included within the initial docblock and the start of the constructor) has been updated
