### PR TITLE
fix: missing conversion from penc…

### DIFF
--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -16,7 +16,7 @@ defined('ABSPATH') or die('Denied');
  * Plugin Name: Finance Payment Gateway for WooCommerce
  * Plugin URI: http://integrations.divido.com/finance-gateway-woocommerce
  * Description: The Finance Payment Gateway plugin for WooCommerce.
- * Version: 2.3.5
+ * Version: 2.3.6
  *
  * Author: Divido Financial Services Ltd
  * Author URI: www.divido.com
@@ -129,7 +129,7 @@ function woocommerce_finance_init()
          */
         function __construct()
         {
-            $this->plugin_version = '2.3.5';
+            $this->plugin_version = '2.3.6';
             add_action('init', array($this, 'wpdocs_load_textdomain'));
 
             $this->id = 'finance';
@@ -620,7 +620,7 @@ jQuery(document).ready(function() {
                     }
                 } elseif ('price' === $this->settings['productSelect']) {
                     $limit = $this->settings['priceSelection'];
-                    if ($this->get_price_including_tax($product, '') > 0 && $this->get_price_including_tax($product, '') >= $limit) {
+                    if ($this->get_price_including_tax($product, '') > 0 && ($this->get_price_including_tax($product, '') / 100) <= $limit) {
                         return true;
                     } else {
                         return false;

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -620,7 +620,7 @@ jQuery(document).ready(function() {
                     }
                 } elseif ('price' === $this->settings['productSelect']) {
                     $limit = $this->settings['priceSelection'];
-                    if ($this->get_price_including_tax($product, '') <= $limit * 100) {
+                    if ($this->get_price_including_tax($product, '') >= $limit * 100) {
                         return true;
                     } else {
                         return false;

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -620,7 +620,7 @@ jQuery(document).ready(function() {
                     }
                 } elseif ('price' === $this->settings['productSelect']) {
                     $limit = $this->settings['priceSelection'];
-                    if ($this->get_price_including_tax($product, '') > 0 && ($this->get_price_including_tax($product, '') / 100) <= $limit) {
+                    if ($this->get_price_including_tax($product, '') <= $limit * 100) {
                         return true;
                     } else {
                         return false;

--- a/readme.txt
+++ b/readme.txt
@@ -7,8 +7,8 @@ Author URI:        integrations.divido.com
 Author:            Divido Financial Services Ltd
 Requires at least: 3.0.2
 Tested up to:      5.7.2
-Stable tag:        2.3.5
-Version:           2.3.5
+Stable tag:        2.3.6
+Version:           2.3.6
 
 License: GPLv2 or later
 
@@ -44,6 +44,9 @@ Enable/Disable Automatic Cancellation: Allows you to select if an "Cancellation"
 
 
  == Changelog ==
+Version 2.3.6
+Fix: Product price threshold had a typo in a mathematical operator and a missing conversion from pence/pennies.
+
 Version 2.3.5
 Fix: Adjusted the way we set values to the plugin config fields.
 


### PR DESCRIPTION
…e/pennies.

### PR CHECKLIST

- [x] All translations are concatenated with an EOT character between the translation context and key (ie. `backend/config[EOT]general_settings_header`)
- [x] The version information documented in the readme.txt has been manually updated in line with semantic versioning
- [x] The readme file's Changelog has been updated with your proposed PR
- [x] The version information in `class-wc-gateway-finance.php` (included within the initial docblock and the start of the constructor) has been updated
