### PR TITLE
feat: LM2-1284 branding lender logo

### DIFF
--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -238,8 +238,8 @@ function woocommerce_finance_init()
         {
             $logoUrl = null;
             foreach($this->get_all_finances() as $plan){
-                if(!empty($plan->lender->branding->logoUrl)){
-                    $logoUrl = $plan->lender->branding->logoUrl;
+                if(!empty($plan->lender->branding->logo_url)){
+                    $logoUrl = $plan->lender->branding->logo_url;
                     break;
                 }
             }

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -236,9 +236,13 @@ function woocommerce_finance_init()
          */
         public function custom_gateway_icon()
         {
-            $plans = $this->get_all_finances();
-            $logoUrl = $plans[0]->lender->branding->logoUrl ?? null;
-
+            $logoUrl = null;
+            foreach($this->get_all_finances() as $plan){
+                if(!empty($plan->lender->branding->logoUrl)){
+                    $logoUrl = $plan->lender->branding->logoUrl;
+                    break;
+                }
+            }
             return ($logoUrl === null)
                 ? null
                 : "<img style='float:right; max-height: 24px' src='{$logoUrl}' />";

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -237,6 +237,7 @@ function woocommerce_finance_init()
         public function custom_gateway_icon()
         {
             $logoUrl = null;
+            set_transient("finances", ""); 
             foreach($this->get_all_finances() as $plan){
                 if(!empty($plan->lender->branding->logo_url)){
                     $logoUrl = $plan->lender->branding->logo_url;

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -1649,7 +1649,7 @@ jQuery(document).ready(function($) {
                 $response = $sdk->platformEnvironments()->getPlatformEnvironment();
                 $finance_env = $response->getBody()->getContents();
                 $decoded = json_decode($finance_env);
-                $global = $decoded->data->environment;
+                $global = $decoded->data->environment ?? null;
                 set_transient($transient, $global, 60 * 5);
 
                 return $global;

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -237,7 +237,7 @@ function woocommerce_finance_init()
         public function custom_gateway_icon()
         {
             $plans = $this->get_all_finances();
-            $logoUrl = $plans[0]->lender->branding->logo ?? null;
+            $logoUrl = $plans[0]->lender->branding->logoUrl ?? null;
 
             return ($logoUrl === null)
                 ? null

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -22,7 +22,7 @@ defined('ABSPATH') or die('Denied');
  * Author URI: www.divido.com
  * Text Domain: woocommerce-finance-gateway
  * Domain Path: /i18n/languages/
- * WC tested up to: 6.0.2
+ * WC tested up to: 7.3.0
  */
 
 /**

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -234,19 +234,23 @@ function woocommerce_finance_init()
          * @param $id
          * @return string
          */
-        public function custom_gateway_icon()
+        public function custom_gateway_icon($icon, $id)
         {
-            $logoUrl = null;
-            set_transient("finances", ""); 
-            foreach($this->get_all_finances() as $plan){
-                if(!empty($plan->lender->branding->logo_url)){
-                    $logoUrl = $plan->lender->branding->logo_url;
-                    break;
+            if($id === 'finance'){
+                $logoUrl = null;
+                set_transient("finances", ""); 
+                foreach($this->get_all_finances() as $plan){
+                    if(!empty($plan->lender->branding->logo_url)){
+                        $logoUrl = $plan->lender->branding->logo_url;
+                        break;
+                    }
                 }
+                return ($logoUrl === null)
+                    ? null
+                    : "<img style='float:right; max-height: 24px' src='{$logoUrl}' />";
+            } else {
+                return $icon;
             }
-            return ($logoUrl === null)
-                ? null
-                : "<img style='float:right; max-height: 24px' src='{$logoUrl}' />";
         }
 
         /**

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -234,19 +234,14 @@ function woocommerce_finance_init()
          * @param $id
          * @return string
          */
-        public function custom_gateway_icon($icon, $id)
+        public function custom_gateway_icon()
         {
-            if ($id === 'finance') {
-                if (empty($this->api_key)) {
-                    return "<img style='float:right;' src='https://cdn.divido.com/widget/themes/divido/logo.png'/>";
-                } else if ($this->get_finance_env() === 'nordea') {
-                    return "<img style='height:24px;float:right;' src='https://cdn.divido.com/widget/themes/" . $this->get_finance_env() . "/logo.png'/>";
-                } else {
-                    return "<img style='float:right;' src='https://cdn.divido.com/widget/themes/" . $this->get_finance_env() . "/logo.png'/>";
-                }
-            } else {
-                return $icon;
-            }
+            $plans = $this->get_all_finances();
+            $logoUrl = $plans[0]->lender->branding->logo ?? null;
+
+            return ($logoUrl === null)
+                ? null
+                : "<img style='float:right; max-height: 24px' src='{$logoUrl}' />";
         }
 
         /**

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -16,13 +16,13 @@ defined('ABSPATH') or die('Denied');
  * Plugin Name: Finance Payment Gateway for WooCommerce
  * Plugin URI: http://integrations.divido.com/finance-gateway-woocommerce
  * Description: The Finance Payment Gateway plugin for WooCommerce.
- * Version: 2.3.8
+ * Version: 2.4.0
  *
  * Author: Divido Financial Services Ltd
  * Author URI: www.divido.com
  * Text Domain: woocommerce-finance-gateway
  * Domain Path: /i18n/languages/
- * WC tested up to: 4.7.1
+ * WC tested up to: 6.0.2
  */
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -6,9 +6,9 @@ Tags:              woothemes,woocommerce,payment gateway,payment,module,ecommerc
 Author URI:        integrations.divido.com
 Author:            Divido Financial Services Ltd
 Requires at least: 3.0.2
-Tested up to:      5.7.2
-Stable tag:        2.3.8
-Version:           2.3.8
+Tested up to:      6.0.2
+Stable tag:        2.4.0
+Version:           2.4.0
 
 License: GPLv2 or later
 
@@ -44,6 +44,9 @@ Enable/Disable Automatic Cancellation: Allows you to select if an "Cancellation"
 
 
  == Changelog ==
+
+Version 2.4.0
+Feat: Retrieves lender logos at checkout dynamically.
 
 Version 2.3.8
 Chore: Added a new icon for finance payment plugin.


### PR DESCRIPTION
PR to retrieve the lender logo from the lender, via the finance plans call to the merchant-api-pub, rather than doing it in an ad-hoc way within the plugin.


### PR CHECKLIST

- [x] All translations are concatenated with an EOT character between the translation context and key (ie. `backend/config[EOT]general_settings_header`)
- [x] The version information documented in the readme.txt has been manually updated in line with semantic versioning
- [x] The readme file's Changelog has been updated with your proposed PR
- [x] The version information in `class-wc-gateway-finance.php` (included within the initial docblock and the start of the constructor) has been updated
