### PR TITLE
feat: LM2-2166 merchant sdk bump

### DIFF
--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -21,7 +21,7 @@ defined('ABSPATH') or die('Denied');
  * Author URI: www.divido.com
  * Text Domain: woocommerce-finance-gateway
  * Domain Path: /i18n/languages/
- * WC tested up to: 7.8
+ * WC tested up to: 7.9
  */
 
 /**

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -15,7 +15,7 @@ defined('ABSPATH') or die('Denied');
  * Plugin Name: Finance Payment Gateway for WooCommerce
  * Plugin URI: http://integrations.divido.com/finance-gateway-woocommerce
  * Description: The Finance Payment Gateway plugin for WooCommerce.
- * Version: 2.5.0
+ * Version: 2.6.0
  *
  * Author: Divido Financial Services Ltd
  * Author URI: www.divido.com
@@ -457,7 +457,7 @@ jQuery(document).ready(function() {
             if (is_object($data_json)) {
                 if ($data_json->metadata->order_number) {
                     $finance_reference = get_post_meta($data_json->metadata->order_number, '_finance_reference');
-                    if (isset($finance_reference[0]) && $finance_reference[0] === $data_json->proposal) {
+                    if (isset($finance_reference[0]) && $finance_reference[0] === $data_json->application) {
                         $order = new WC_Order($data_json->metadata->order_number);
                         $finance_amount = get_post_meta($data_json->metadata->order_number, '_finance_amount');
                         // Check if the requested amount matched order amount.

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -94,7 +94,7 @@ function woocommerce_finance_init()
          */
         function __construct()
         {
-            $this->plugin_version = '2.3.8';
+            $this->plugin_version = '2.6.0';
             add_action('init', array($this, 'wpdocs_load_textdomain'));
 
             $this->id = 'finance';

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -1,8 +1,7 @@
 <?php
 
 use Divido\MerchantSDK\Environment;
-use Divido\MerchantSDK\Exceptions\InvalidApiKeyFormatException;
-use Divido\MerchantSDK\Exceptions\InvalidEnvironmentException;
+use Divido\Woocommerce\FinanceGateway\Proxies\MerchantApiPubProxy;
 
 defined('ABSPATH') or die('Denied');
 /**
@@ -41,42 +40,6 @@ function woocommerce_finance_init()
         return;
     }
     include_once WP_PLUGIN_DIR . '/' . plugin_basename(dirname(__FILE__)) . '/vendor/autoload.php';
-
-    /**
-     * Merchant SDK class
-     *
-     * Constructs an instance of the merchant sdk to be used
-     **/
-    class Merchant_SDK
-    {
-        /**
-         * Creates and returns a merchant sdk instance
-         *
-         * @param string The merchant api url
-         * @param string The api key for the environment
-         *
-         * @return Divido\MerchantSDK\Client|null The Merchant SDK client instance
-         */
-        public static function getSDK($url, $api_key)
-        {
-            try{
-                $env = Environment::getEnvironmentFromAPIKey($api_key);
-            }catch (InvalidApiKeyFormatException $e){
-                return null;
-            }catch (InvalidEnvironmentException $e){
-                return null;
-            }
-
-            $client = new \GuzzleHttp\Client();
-            $httpClientWrapper = new \Divido\MerchantSDK\HttpClient\HttpClientWrapper(
-                new \Divido\MerchantSDKGuzzle6\GuzzleAdapter($client),
-                $url,
-                $api_key
-            );
-
-            return new \Divido\MerchantSDK\Client($httpClientWrapper, $env);
-        }
-    }
 
     /**
      * Finance Payment Gateway class
@@ -338,17 +301,13 @@ function woocommerce_finance_init()
             // OR finances transient is not set
             if ($apiKey !== $this->api_key || empty($apiKey) || empty($finances)) {
 
-                $request_options = (new \Divido\MerchantSDK\Handlers\ApiRequestOptions());
                 // Retrieve all finance plans for the merchant.
                 try {
-                    $sdk = Merchant_SDK::getSDK($this->url, $this->api_key);
+                    $proxy = new MerchantApiPubProxy($this->url, $this->api_key);
 
-                    if($sdk === null){
-                        return [];
-                    }
+                    $response = $proxy->getFinancePlans();
+                    $plans = $response->data;
 
-                    $plans = $sdk->getAllPlans($request_options);
-                    $plans = $plans->getResources();
                     set_transient($transient_name, $plans, 60 * 60 * 1);
                     set_transient("api_key", $this->api_key);
 
@@ -1212,18 +1171,17 @@ jQuery("input[name=_tab_finance_active]").change(function() {
          *
          */
         function admin_options()
-        {
-            $sdk = Merchant_SDK::getSDK($this->url, $this->api_key);
+        {   
+            $proxy = new MerchantApiPubProxy($this->url, $this->api_key);
 
-            $status_code = null;
+            $status_code = 200;
 
-            if($sdk !== null){
-                $response = $sdk->health()->checkHealth();
-
-                if(array_key_exists('status_code', $response) && !empty($response['status_code'])){
-                    $status_code = $response['status_code'];
-                }
+            try{
+                $response = $proxy->getHealth();
+            }catch (\Exception $e){
+                $status_code = $e->getCode();
             }
+        
 
             $bad_host = !$status_code;
             $not_200 = $status_code !== 200;
@@ -1481,8 +1439,7 @@ jQuery(document).ready(function($) {
                     );
                 }
 
-                // Todo: Should check if SDK is not null.
-                $sdk = Merchant_SDK::getSDK($this->url, $this->api_key);
+                $proxy = new MerchantApiPubProxy($this->url, $this->api_key);
 
                 $application = (new \Divido\MerchantSDK\Models\Application())
                     ->withCountryId($order->get_billing_country())
@@ -1519,24 +1476,21 @@ jQuery(document).ready(function($) {
                         'merchant_reference'    => strval($order_id)
                     ]);
 
-                $headers = ['Content-Type' => 'application/json'];
                 if ('' !== $this->secret) {
                     $secret = $this->create_signature(json_encode($application->getPayload()), $this->secret);
-                    $headers['X-Divido-Hmac-Sha256'] = $secret;
+                    $proxy->addSecretHeader($secret);
                 }
                 
                 if (empty(get_post_meta($order_id, "_finance_reference", true))) {
-                    $response = $sdk->applications()->createApplication($application, [], $headers);
+                    $response = $proxy->postApplication($application);
                 } else {
                     $applicationId = get_post_meta($order_id, "_finance_reference", true);
                     $application = $application->withId($applicationId);
-                    $response = $sdk->applications()->updateApplication($application, [], $headers);
+                    $response = $proxy->updateApplication($application);
                 }
-                $application_response_body = $response->getBody()->getContents();
-                $decode = json_decode($application_response_body);
 
-                $result_id = $decode->data->id;
-                $result_redirect = $decode->data->urls->application_url;
+                $result_id = $response->data->id;
+                $result_redirect = $response->data->urls->application_url;
                 
             }
 
@@ -1603,12 +1557,7 @@ jQuery(document).ready(function($) {
          */
         public function get_finance_env()
         {
-            $sdk = Merchant_SDK::getSDK($this->url, $this->api_key);
-
-            //Todo: Perhaps show the user some error message? This will break a bunch of stuff.
-            if($sdk === null) {
-                return '';
-            }
+            $proxy = new MerchantApiPubProxy($this->url, $this->api_key);
 
             // ensure that the url is used as a part of the cache key so the right env is returned from the cache
             $transient = 'environment' . md5($this->url);
@@ -1617,10 +1566,8 @@ jQuery(document).ready(function($) {
             if (!empty($setting)) {
                 return $setting;
             } else {
-                $response = $sdk->platformEnvironments()->getPlatformEnvironment();
-                $finance_env = $response->getBody()->getContents();
-                $decoded = json_decode($finance_env);
-                $global = $decoded->data->environment ?? null;
+                $response = $proxy->getEnvironment();
+                $global = $response->data->environment ?? null;
                 set_transient($transient, $global, 60 * 5);
 
                 return $global;
@@ -1859,9 +1806,6 @@ jQuery(document).ready(function($) {
          */
         function set_cancelled($application_id, $order_total, $order_id)
         {
-            // First get the application you wish to refund.
-            $application = (new \Divido\MerchantSDK\Models\Application())
-                ->withId($application_id);
             $items = [
                 [
                     'name' => __('globalorder_id_label', 'woocommerce-finance-gateway') . ": $order_id",
@@ -1874,16 +1818,12 @@ jQuery(document).ready(function($) {
                 ->withOrderItems($items);
 
             //Todo: Check if SDK is null
-            $sdk = Merchant_SDK::getSDK($this->url, $this->api_key);
-            $response = $sdk->applicationCancellations()->createApplicationCancellation($application, $applicationCancellation);
-            $refundResponseBody = $response->getBody()->getContents();
+            $proxy = new MerchantApiPubProxy($this->url, $this->api_key);
+            $proxy->postCancellation($application_id, $applicationCancellation);
         }
 
         function set_refund($application_id, $order_total, $order_id)
         {
-            // First get the application you wish to refund.
-            $application = (new \Divido\MerchantSDK\Models\Application())
-                ->withId($application_id);
             $items = [
                 [
                     'name' => __('globalorder_id_label', 'woocommerce-finance-gateway') . ": $order_id",
@@ -1896,16 +1836,12 @@ jQuery(document).ready(function($) {
                 ->withOrderItems($items);
 
             //Todo: Check if SDK is null
-            $sdk = Merchant_SDK::getSDK($this->url, $this->api_key);
-            $response = $sdk->applicationRefunds()->createApplicationRefund($application, $applicationRefund);
-            $refundResponseBody = $response->getBody()->getContents();
+            $proxy = new MerchantApiPubProxy($this->url, $this->api_key);
+            $proxy->postRefund($application_id, $applicationRefund);
         }
 
         function set_fulfilled($application_id, $order_total, $order_id, $shipping_method = null, $tracking_numbers = null)
         {
-            // First get the application you wish to create an activation for.
-            $application = (new \Divido\MerchantSDK\Models\Application())
-                ->withId($application_id);
             $items = [
                 [
                     'name' => __('globalorder_id_label', 'woocommerce-finance-gateway') . ": $order_id",
@@ -1920,9 +1856,8 @@ jQuery(document).ready(function($) {
                 ->withTrackingNumber($tracking_numbers);
             // Create a new activation for the application.
             //Todo: Check if SDK is null
-            $sdk = Merchant_SDK::getSDK($this->url, $this->api_key);
-            $response = $sdk->applicationActivations()->createApplicationActivation($application, $application_activation);
-            $activation_response_body = $response->getBody()->getContents();
+            $proxy = new MerchantApiPubProxy($this->url, $this->api_key);
+            $proxy->postActivation($application_id, $application_activation);
         }
 
         /**

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -1481,12 +1481,6 @@ jQuery(document).ready(function($) {
                     );
                 }
 
-                if (isset($_SERVER['HTTP_RAW_POST_DATA']) && wp_unslash($_SERVER['HTTP_RAW_POST_DATA'])) { // Input var okay.
-                    $data = file_get_contents(wp_unslash($_SERVER['HTTP_RAW_POST_DATA'])); // Input var okay.
-                } else {
-                    $data = file_get_contents('php://input');
-                }
-
                 // Todo: Should check if SDK is not null.
                 $sdk = Merchant_SDK::getSDK($this->url, $this->api_key);
 

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,15 @@
 {
     "require": {
         "php": ">=5",
-        "divido/merchant-sdk-guzzle-6": "dev-master",
-        "divido/merchant-sdk": "v2.5.0"
+        "divido/merchant-sdk": "^3.1"
     },
     "conflict": {
         "symfony/polyfill-intl-idn": ">=1.18",
         "symfony/polyfill-mbstring": ">=1.22.0"
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,15 @@
         "allow-plugins": {
             "php-http/discovery": true
         }
+    },
+    "autoload": {
+        "psr-4": {
+          
+        },
+        "files": [
+            "includes/proxies/MerchantApiPubProxy.php",
+            "includes/wrappers/HttpApiWrapper.php",
+            "includes/exceptions/ResponseException.php"
+        ]
     }
 }

--- a/includes/exceptions/ResponseException.php
+++ b/includes/exceptions/ResponseException.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Divido\Woocommerce\FinanceGateway\Exceptions;
+
+class ResponseException extends \Exception{
+
+    private $method;
+    private $action;
+
+    public function __construct(string $message, ?int $code=0, ?string $method=null, ?string $action=null){
+        $this->method = $method;
+        $this->action = $action;
+
+        parent::__construct($message, $code);
+    }
+
+    public function getMethod(){
+        return $this->method;
+    }
+
+    public function getAction(){
+        return $this->action;
+    }
+
+
+}

--- a/includes/proxies/MerchantApiPubProxy.php
+++ b/includes/proxies/MerchantApiPubProxy.php
@@ -10,6 +10,9 @@ use Divido\MerchantSDK\Models\ApplicationRefund;
 use Divido\Woocommerce\FinanceGateway\Exceptions\ResponseException;
 use Divido\Woocommerce\FinanceGateway\Wrappers\HttpApiWrapper;
 
+/**
+ * A proxy between the Merchant API Pub and the HttpApiWrapper
+ */
 class MerchantApiPubProxy{
 
     const PATHS = [

--- a/includes/proxies/MerchantApiPubProxy.php
+++ b/includes/proxies/MerchantApiPubProxy.php
@@ -60,10 +60,21 @@ class MerchantApiPubProxy{
         $this->wrapper->addHeader(self::HEADER_KEYS['API_KEY'], $apiKey);
     }
 
+    /**
+     * Adds the shared secret header to our HTTP request
+     *
+     * @param string $secret
+     * @return void
+     */
     public function addSecretHeader(string $secret){
         $this->wrapper->addHeader(self::HEADER_KEYS['SHARED_SECRET'], $secret);
     }
 
+    /**
+     * Makes a request to the Merchant API Pub health endpoint and returns true if API is healthy
+     *
+     * @return boolean
+     */
     public function getHealth():bool{
         $method = 'GET';
         $action = 'HEALTH';
@@ -76,7 +87,12 @@ class MerchantApiPubProxy{
         );
     }
 
-
+    /**
+     * Makes a request to the environment endpoint, and returns a json
+     * object of the response body
+     *
+     * @return object
+     */
     public function getEnvironment():object{
         $method = 'GET';
         $action = 'ENVIRONMENT';
@@ -88,6 +104,12 @@ class MerchantApiPubProxy{
         return $this->responseToObj($response);
     }
 
+    /**
+     * Makes a request to the finance plans endpoint, and returns a json
+     * object of the response body
+     *
+     * @return object
+     */
     public function getFinancePlans() :object{
         $method = 'GET';
         $action = 'PLANS';
@@ -99,6 +121,13 @@ class MerchantApiPubProxy{
         return $this->responseToObj($response);
     }
 
+    /**
+     * Makes a request to create an application, and returns a json
+     * object of the response body
+     *
+     * @param Application $application
+     * @return object
+     */
     public function postApplication(Application $application): object{
         $method = 'POST';
         $action = 'APPLICATION';
@@ -112,6 +141,14 @@ class MerchantApiPubProxy{
         return $this->responseToObj($response);
     }
 
+    /**
+     * Makes a request to create an activation, and returns a json
+     * object of the response body
+     *
+     * @param string $applicationId
+     * @param ApplicationActivation $activation
+     * @return object
+     */
     public function postActivation(string $applicationId, ApplicationActivation $activation): object{
         $method = 'POST';
         $action = 'ACTIVATION';
@@ -130,6 +167,14 @@ class MerchantApiPubProxy{
         return $this->responseToObj($response);
     }
 
+    /**
+     * Makes a request to create a cancellation, and returns a json
+     * object of the response body
+     *
+     * @param string $applicationId
+     * @param ApplicationCancellation $cancellation
+     * @return object
+     */
     public function postCancellation(string $applicationId, ApplicationCancellation $cancellation): object{
         $method = 'POST';
         $action = 'CANCELLATION';
@@ -147,6 +192,14 @@ class MerchantApiPubProxy{
         return $this->responseToObj($response);
     }
 
+    /**
+     * Makes a request to create a refund, and returns a json
+     * object of the response body
+     *
+     * @param string $applicationId
+     * @param ApplicationRefund $refund
+     * @return object
+     */
     public function postRefund(string $applicationId, ApplicationRefund $refund): object{
         $method = 'POST';
         $action = 'REFUND';
@@ -165,7 +218,13 @@ class MerchantApiPubProxy{
     }
 
     
-
+    /**
+     * Makes a request to update an application, and returns a json
+     * object of the response body
+     *
+     * @param Application $application
+     * @return object
+     */
     public function updateApplication(Application $application): object{
         $method = 'PATCH';
         $action = 'APPLICATION';
@@ -184,7 +243,15 @@ class MerchantApiPubProxy{
         return $this->responseToObj($response);
     }
 
-    private function validateResponse($method, $action, $response){
+    /**
+     * Checks the response is as expected
+     *
+     * @param string $method
+     * @param string $action
+     * @param array $response
+     * @return void
+     */
+    private function validateResponse(string $method, string $action, array $response){
         $body = $this->responseToObj($response);
         if(isset($body->error) && $body->error === true && isset($body->code)){
             throw new MerchantApiBadResponseException(
@@ -204,7 +271,18 @@ class MerchantApiPubProxy{
         }
     }
 
+    /**
+     * Attempts to turn the body of the response into a json object
+     *
+     * @param array $response
+     * @return object
+     */
     private function responseToObj(array $response):object{
-        return json_decode(wp_remote_retrieve_body($response), false, 512, JSON_THROW_ON_ERROR);
+        return json_decode(
+            wp_remote_retrieve_body($response), 
+            false, 
+            512, 
+            JSON_THROW_ON_ERROR
+        );
     }
 }

--- a/includes/proxies/MerchantApiPubProxy.php
+++ b/includes/proxies/MerchantApiPubProxy.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace Divido\Woocommerce\FinanceGateway\Proxies;
+
+use Divido\MerchantSDK\Exceptions\MerchantApiBadResponseException;
+use Divido\MerchantSDK\Models\Application;
+use Divido\MerchantSDK\Models\ApplicationActivation;
+use Divido\MerchantSDK\Models\ApplicationCancellation;
+use Divido\MerchantSDK\Models\ApplicationRefund;
+use Divido\Woocommerce\FinanceGateway\Exceptions\ResponseException;
+use Divido\Woocommerce\FinanceGateway\Wrappers\HttpApiWrapper;
+
+class MerchantApiPubProxy{
+
+    const PATHS = [
+        'GET' => [
+            'HEALTH' => '/health',
+            'PLANS' => '/finance-plans',
+            'ENVIRONMENT' => '/environment'
+        ],
+        'POST' => [
+            'APPLICATION' => '/applications',
+            'ACTIVATION' => '/applications/%s/activations',
+            'REFUND' => '/application/%s/refunds',
+            'CANCELLATION' => '/applications/%s/cancellations'
+        ],
+        'PATCH' => [
+            'APPLICATION' => '/application/%s'
+        ]
+    ];
+
+    const EXPECTED_RESPONSE_CODES = [
+        'GET' => [
+            'HEALTH' => 200,
+            'PLANS' => 200,
+            'ENVIRONMENT' => 200
+        ],
+        'POST' => [
+            'APPLICATION' => 201,
+            'ACTIVATION' => 201,
+            'REFUND' => 201,
+            'CANCELLATION' => 201
+        ],
+        'PATCH' => [
+            'APPLICATION' => 200
+        ]
+    ];
+
+    const HEADER_KEYS = [
+        'API_KEY' => 'X-DIVIDO-API-KEY',
+        'SHARED_SECRET' => 'X-Divido-Hmac-Sha256'
+    ];
+
+    private HttpApiWrapper $wrapper;
+
+    public function __construct(string $baseUri, string $apiKey){
+        $this->wrapper = new HttpApiWrapper($baseUri);
+        $this->wrapper->addHeader('Accept', 'application/json');
+        $this->wrapper->addHeader('Content-Type', 'application/json');
+        $this->wrapper->addHeader(self::HEADER_KEYS['API_KEY'], $apiKey);
+    }
+
+    public function addSecretHeader(string $secret){
+        $this->wrapper->addHeader(self::HEADER_KEYS['SHARED_SECRET'], $secret);
+    }
+
+    public function getHealth():bool{
+        $method = 'GET';
+        $action = 'HEALTH';
+
+        $response = $this->wrapper->get(self::PATHS[$method][$action]);
+        
+        return (
+            wp_remote_retrieve_body($response) == 'OK' && 
+            wp_remote_retrieve_response_code($response) === 200
+        );
+    }
+
+
+    public function getEnvironment():object{
+        $method = 'GET';
+        $action = 'ENVIRONMENT';
+
+        $response = $this->wrapper->get(self::PATHS[$method][$action]);
+        
+        $this->validateResponse($method, $action, $response);
+        
+        return $this->responseToObj($response);
+    }
+
+    public function getFinancePlans() :object{
+        $method = 'GET';
+        $action = 'PLANS';
+
+        $response = $this->wrapper->get(self::PATHS[$method][$action]);
+        
+        $this->validateResponse($method, $action, $response);
+        
+        return $this->responseToObj($response);
+    }
+
+    public function postApplication(Application $application): object{
+        $method = 'POST';
+        $action = 'APPLICATION';
+
+        $body = $application->getJsonPayload();
+        
+        $response = $this->wrapper->post(self::PATHS[$method][$action], $body);
+        
+        $this->validateResponse($method, $action, $response);
+
+        return $this->responseToObj($response);
+    }
+
+    public function postActivation(string $applicationId, ApplicationActivation $activation): object{
+        $method = 'POST';
+        $action = 'ACTIVATION';
+
+        $body = $activation->getJsonPayload();
+
+        $path = sprintf(
+            self::PATHS[$method][$action],
+            $applicationId
+        );
+
+        $response = $this->wrapper->post($path, $body);
+
+        $this->validateResponse($method, $action, $response);
+
+        return $this->responseToObj($response);
+    }
+
+    public function postCancellation(string $applicationId, ApplicationCancellation $cancellation): object{
+        $method = 'POST';
+        $action = 'CANCELLATION';
+
+        $path = sprintf(
+            self::PATHS[$method][$action],
+            $applicationId
+        );
+
+        $body = $cancellation->getJsonPayload();
+        $response = $this->wrapper->post($path, $body);
+
+        $this->validateResponse($method, $action, $response);
+
+        return $this->responseToObj($response);
+    }
+
+    public function postRefund(string $applicationId, ApplicationRefund $refund): object{
+        $method = 'POST';
+        $action = 'REFUND';
+
+        $path = sprintf(
+            self::PATHS[$method][$action],
+            $applicationId
+        );
+
+        $body = $refund->getJsonPayload();
+        $response = $this->wrapper->post($path, $body);
+
+        $this->validateResponse($method, $action, $response);
+
+        return $this->responseToObj($response);
+    }
+
+    
+
+    public function updateApplication(Application $application): object{
+        $method = 'PATCH';
+        $action = 'APPLICATION';
+
+        $body = $application->getPayload();
+
+        $path = sprintf(
+            self::PATHS[$method][$action],
+            $application->getId()
+        );
+
+        $response = $this->wrapper->patch($path, $body);
+
+        $this->validateResponse($method, $action, $response);
+
+        return $this->responseToObj($response);
+    }
+
+    private function validateResponse($method, $action, $response){
+        $body = $this->responseToObj($response);
+        if(isset($body->error) && $body->error === true && isset($body->code)){
+            throw new MerchantApiBadResponseException(
+                $body->message ?? "An error occured",
+                $body->code,
+                [
+                    'method' => $method,
+                    'action' => $action
+                ]
+            );
+        }
+        $statusCode = wp_remote_retrieve_response_code($response);
+        if($statusCode !== self::EXPECTED_RESPONSE_CODES[$method][$action]){
+            throw new ResponseException(
+                "An unexpected error occurred when contacting the Merchant API Pub", $statusCode, $action, $method
+            );
+        }
+    }
+
+    private function responseToObj(array $response):object{
+        return json_decode(wp_remote_retrieve_body($response), false, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/includes/proxies/MerchantApiPubProxy.php
+++ b/includes/proxies/MerchantApiPubProxy.php
@@ -267,6 +267,11 @@ class MerchantApiPubProxy{
             );
         }
         $statusCode = wp_remote_retrieve_response_code($response);
+        if(!is_int($statusCode)){
+            throw new ResponseException(
+                "There was an unexpected problem with the response received from the request", 500, $action, $method
+            );
+        }
         if($statusCode !== self::EXPECTED_RESPONSE_CODES[$method][$action]){
             throw new ResponseException(
                 "An unexpected error occurred when contacting the Merchant API Pub", $statusCode, $action, $method

--- a/includes/wrappers/HttpApiWrapper.php
+++ b/includes/wrappers/HttpApiWrapper.php
@@ -78,9 +78,18 @@ class HttpApiWrapper{
     }
 
     private function validateResponse($response, $method, $path){
-        if(!is_array($response) && get_class($response) === 'WP_Error'){
+        if(is_object($response) && get_class($response) === 'WP_Error'){
             throw new ResponseException(
                 sprintf("Error in response: %s", $response->get_error_message()),
+                500,
+                $method,
+                $path
+            );
+        }
+
+        if(!is_array($response)){
+            throw new ResponseException(
+                "Unexpected Response - expected array",
                 500,
                 $method,
                 $path

--- a/includes/wrappers/HttpApiWrapper.php
+++ b/includes/wrappers/HttpApiWrapper.php
@@ -3,6 +3,11 @@
 namespace Divido\Woocommerce\FinanceGateway\Wrappers;
 use Divido\Woocommerce\FinanceGateway\Exceptions\ResponseException;
 
+/**
+ * A Wrapper for the Wordpress HTTP API functions
+ * https://developer.wordpress.org/plugins/http-api/
+ * 
+ */
 class HttpApiWrapper{
 
     private string $baseUri;
@@ -77,7 +82,16 @@ class HttpApiWrapper{
         return $response;
     }
 
-    private function validateResponse($response, $method, $path){
+    /**
+     * Ensures we're actually receiving an array, as expected from the wp_remote_ functions
+     * https://developer.wordpress.org/reference/functions/wp_remote_post/
+     *
+     * @param array|WP_Error $response
+     * @param string $method
+     * @param string $path
+     * @return void
+     */
+    private function validateResponse($response, string $method, string $path){
         if(is_object($response) && get_class($response) === 'WP_Error'){
             throw new ResponseException(
                 sprintf("Error in response: %s", $response->get_error_message()),

--- a/includes/wrappers/HttpApiWrapper.php
+++ b/includes/wrappers/HttpApiWrapper.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Divido\Woocommerce\FinanceGateway\Wrappers;
+use Divido\Woocommerce\FinanceGateway\Exceptions\ResponseException;
+
+class HttpApiWrapper{
+
+    private string $baseUri;
+    private array $headers = [];
+
+    public function __construct(string $baseUri){
+        $this->baseUri = $baseUri;
+    }
+
+    public function addHeader(string $key, string $value){
+        $this->headers[$key] = $value;
+    }
+
+    public function get(string $path, ?array $params = null):array{
+
+        $args = [
+            'method' => 'GET',
+            'headers' => $this->headers
+        ];
+
+        $url = sprintf("%s%s", $this->baseUri, $path);
+        if($params){
+            $queryParams = http_build_query($params);
+            $url .= sprintf("?%s", $queryParams);
+        }
+
+        $response = wp_remote_get(
+            $url,
+            $args
+        );
+
+        $this->validateResponse($response, 'GET', $path);
+
+        return $response;
+    }
+
+    public function post(string $path, mixed $body): array{
+        $args = [
+            'method' => 'POST',
+            'headers' => $this->headers,
+            'body' => $body
+        ];
+
+        $url = sprintf("%s%s", $this->baseUri, $path);
+
+        $response = wp_remote_post(
+            $url,
+            $args
+        );
+        
+        $this->validateResponse($response, 'POST', $path);
+
+        return $response;
+    }
+
+    public function patch(string $path, mixed $body):array{
+        $args = [
+            'method' => 'PATCH',
+            'headers' => $this->headers,
+            'body' => $body
+        ];
+
+        $url = sprintf("%s%s?%s", $this->baseUri, $path);
+
+        $response = wp_remote_post(
+            $url,
+            $args
+        );
+
+        $this->validateResponse($response, 'PATCH', $path);
+
+        return $response;
+    }
+
+    private function validateResponse($response, $method, $path){
+        if(!is_array($response) && get_class($response) === 'WP_Error'){
+            throw new ResponseException(
+                sprintf("Error in response: %s", $response->get_error_message()),
+                500,
+                $method,
+                $path
+            );
+        }
+    }
+
+}

--- a/readme.txt
+++ b/readme.txt
@@ -45,6 +45,9 @@ Enable/Disable Automatic Cancellation: Allows you to select if an "Cancellation"
 
  == Changelog ==
 
+Version 2.6.0
+Feat: Removes Guzzle dependancy
+
 Version 2.5.0
 Feat: Adds compatibility to the latest version of our Finance Calculator.
 


### PR DESCRIPTION
This PR looks to bump the Merchant API SDK to a version compatible with *reasons*, before work to wedge reasons into the Wordpress admin interface 

That's the headline. In reality, this PR looks to do away with the use of `divido/merchant-sdk-guzzle-6` a) so that we can send that repo into cold storage and b) so that we don't have a guzzle dependency for our plugin (which is causing issues with plugins also utilising versions of Guzzle).A smarter person may have created their own PSR7 Client. I've instead utilised the [Wordpress HTTP API](https://developer.wordpress.org/plugins/http-api/#get-the-body-you-always-wanted) to handle all http requests, and done away with HTTP Clients altogether. We're instead just using the SDK to construct the payload for the requests.

PR also fixes a small but fairly cataclysmic bug with Webhooks

### PR CHECKLIST

- [x] All translations are concatenated with an EOT character between the translation context and key (ie. `backend/config[EOT]general_settings_header`)
- [x] The version information documented in the readme.txt has been manually updated in line with semantic versioning
- [x] The readme file's Changelog has been updated with your proposed PR
- [x] The version information in `class-wc-gateway-finance.php` (included within the initial docblock and the start of the constructor) has been updated
