### PR TITLE
chore: increase timeout

### DIFF
--- a/includes/proxies/MerchantApiPubProxy.php
+++ b/includes/proxies/MerchantApiPubProxy.php
@@ -58,9 +58,9 @@ class MerchantApiPubProxy{
 
     public function __construct(string $baseUri, string $apiKey){
         $this->wrapper = new HttpApiWrapper($baseUri);
-        $this->wrapper->addHeader('Accept', 'application/json');
-        $this->wrapper->addHeader('Content-Type', 'application/json');
-        $this->wrapper->addHeader(self::HEADER_KEYS['API_KEY'], $apiKey);
+        $this->wrapper->setHeader('Accept', 'application/json');
+        $this->wrapper->setHeader('Content-Type', 'application/json');
+        $this->wrapper->setHeader(self::HEADER_KEYS['API_KEY'], $apiKey);
     }
 
     /**
@@ -70,7 +70,7 @@ class MerchantApiPubProxy{
      * @return void
      */
     public function addSecretHeader(string $secret){
-        $this->wrapper->addHeader(self::HEADER_KEYS['SHARED_SECRET'], $secret);
+        $this->wrapper->setHeader(self::HEADER_KEYS['SHARED_SECRET'], $secret);
     }
 
     /**

--- a/includes/wrappers/HttpApiWrapper.php
+++ b/includes/wrappers/HttpApiWrapper.php
@@ -21,7 +21,7 @@ class HttpApiWrapper{
         $this->baseUri = $baseUri;
     }
 
-    public function addHeader(string $key, string $value){
+    public function setHeader(string $key, string $value){
         $this->defaultArgs['headers'][$key] = $value;
     }
 

--- a/includes/wrappers/HttpApiWrapper.php
+++ b/includes/wrappers/HttpApiWrapper.php
@@ -10,23 +10,26 @@ use Divido\Woocommerce\FinanceGateway\Exceptions\ResponseException;
  */
 class HttpApiWrapper{
 
+    const TIMEOUT = '30';
     private string $baseUri;
-    private array $headers = [];
+    private array $defaultArgs = [
+        'timeout' => self::TIMEOUT,
+        'headers' => []
+    ];
 
     public function __construct(string $baseUri){
         $this->baseUri = $baseUri;
     }
 
     public function addHeader(string $key, string $value){
-        $this->headers[$key] = $value;
+        $this->defaultArgs['headers'][$key] = $value;
     }
 
     public function get(string $path, ?array $params = null):array{
 
-        $args = [
-            'method' => 'GET',
-            'headers' => $this->headers
-        ];
+        $args = array_merge($this->defaultArgs, [
+            'method' => 'GET'
+        ]);
 
         $url = sprintf("%s%s", $this->baseUri, $path);
         if($params){
@@ -45,11 +48,10 @@ class HttpApiWrapper{
     }
 
     public function post(string $path, mixed $body): array{
-        $args = [
+        $args = array_merge($this->defaultArgs, [
             'method' => 'POST',
-            'headers' => $this->headers,
             'body' => $body
-        ];
+        ]);
 
         $url = sprintf("%s%s", $this->baseUri, $path);
 
@@ -64,11 +66,10 @@ class HttpApiWrapper{
     }
 
     public function patch(string $path, mixed $body):array{
-        $args = [
+        $args = array_merge($this->defaultArgs, [
             'method' => 'PATCH',
-            'headers' => $this->headers,
             'body' => $body
-        ];
+        ]);
 
         $url = sprintf("%s%s?%s", $this->baseUri, $path);
 


### PR DESCRIPTION
TLDR; This PR bumps the HTTP API timeout from 5 seconds to 30 seconds

Auto-activations are currently returning the following error on staging:

> Error during status transition. Error in response: cURL error 28: Operation timed out after 5001 milliseconds with 0 bytes received

I don't envision this being an issue on Prod, as we should receive the response quicker, but probably best to err on the side of caution and bump it up to 30 seconds, plus, it's always handy for things to actually work in Staging, especially when it's not particularly detrimental to the customer experience

### PR CHECKLIST

- [ ] All translations are concatenated with an EOT character between the translation context and key (ie. `backend/config[EOT]general_settings_header`)
- [ ] The version information documented in the readme.txt has been manually updated in line with semantic versioning
- [ ] The readme file's Changelog has been updated with your proposed PR
- [ ] The version information in `class-wc-gateway-finance.php` (included within the initial docblock and the start of the constructor) has been updated
