### PR TITLE
chore: bumps version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,8 +7,8 @@ Author URI:        integrations.divido.com
 Author:            Divido Financial Services Ltd
 Requires at least: 3.0.2
 Tested up to:      6.2.2
-Stable tag:        2.5.0
-Version:           2.5.0
+Stable tag:        2.6.0
+Version:           2.6.0
 
 License: GPLv2 or later
 


### PR DESCRIPTION
Missed a version bump in the readme. Should align with the version [here](https://github.com/dividohq/finance-plugin-woocommerce/blob/8860ef1c67c4c618044c53ee1fc9a16e84c9f2a8/class-wc-gateway-finance.php#L18C7-L18C7)

### PR CHECKLIST

- [x] All translations are concatenated with an EOT character between the translation context and key (ie. `backend/config[EOT]general_settings_header`)
- [x] The version information documented in the readme.txt has been manually updated in line with semantic versioning
- [x] The readme file's Changelog has been updated with your proposed PR
- [x] The version information in `class-wc-gateway-finance.php` (included within the initial docblock and the start of the constructor) has been updated
