### PR TITLE
fix: SCB-2021 product shortcode extension

### DIFF
--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -72,6 +72,8 @@ function woocommerce_finance_init()
         const INLINE_CALCULATOR_MODE = 'calculator';
         const LIGHTBOX_CALCULATOR_MODE = 'lightbox';
 
+        const DEFAULT_SHORTCODE_AMOUNT = 1000;
+
         function wpdocs_load_textdomain()
         {
             if (!load_plugin_textdomain(
@@ -267,7 +269,7 @@ function woocommerce_finance_init()
             $this->enqueue();
 
             $attributes = shortcode_atts(array(
-                'amount' => 250,
+                'amount' => null,
                 'mode' => self::INLINE_CALCULATOR_MODE,
                 'button_text' => '',
                 'plans' => '',
@@ -277,10 +279,6 @@ function woocommerce_finance_init()
             $mode = ($attributes['mode'] === self::LIGHTBOX_CALCULATOR_MODE)
                 ? self::LIGHTBOX_CALCULATOR_MODE
                 : self::INLINE_CALCULATOR_MODE;
-
-            $plansStr = (!empty($attributes["plans"] && is_string($attributes["plans"])))
-                ? $attributes["plans"]
-                : $this->convert_plans_to_comma_seperated_string($this->get_short_plans_array());
 
             $buttonText = '';
             if(!empty($attributes["button_text"] && is_string($attributes['button_text']))){
@@ -292,7 +290,33 @@ function woocommerce_finance_init()
                 ? sprintf('data-footnote="%s"', $attributes["footnote"])
                 : '';
             
-            $amount = $this->toPence($attributes['amount']);
+            if (is_product()){
+                global $product;
+                if($this->doesProductMeetWidgetThreshold($product) === false){
+                    return;
+                }
+                $plans = $this->get_short_plans_array();
+                if (
+                    isset($this->settings['productSelect'])
+                    && $this->settings['productSelect'] === 'selected'
+                ) {
+                    $plans = $this->filterPlansByProduct($product, $plans);
+                }
+                if(count($plans) === 0){
+                    return;
+                }
+                $plansStr = $this->convert_plans_to_comma_seperated_string($plans);
+                $amount = $this->toPence($product->get_price());
+            } else {
+                $amount = (isset($attributes['amount']) && is_numeric($attributes['amount']))
+                    ? $this->toPence(floatval($attributes['amount']))
+                    : $this->toPence(self::DEFAULT_SHORTCODE_AMOUNT);
+                
+                $plansStr = (!empty($attributes["plans"] && is_string($attributes["plans"])))
+                    ? $attributes["plans"]
+                    : $this->convert_plans_to_comma_seperated_string($this->get_short_plans_array());
+                
+            }
 
             return sprintf(
                 '<div data-calculator-widget data-mode="%s" data-amount="%d" %s %s data-plans="%s" ></div>',

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -15,7 +15,7 @@ defined('ABSPATH') or die('Denied');
  * Plugin Name: Finance Payment Gateway for WooCommerce
  * Plugin URI: http://integrations.divido.com/finance-gateway-woocommerce
  * Description: The Finance Payment Gateway plugin for WooCommerce.
- * Version: 2.6.1
+ * Version: 2.6.2
  *
  * Author: Divido Financial Services Ltd
  * Author URI: www.divido.com
@@ -106,7 +106,7 @@ function woocommerce_finance_init()
          */
         function __construct()
         {
-            $this->plugin_version = '2.6.1';
+            $this->plugin_version = '2.6.2';
             add_action('init', array($this, 'wpdocs_load_textdomain'));
 
             $this->id = 'finance';

--- a/includes/proxies/MerchantApiPubProxy.php
+++ b/includes/proxies/MerchantApiPubProxy.php
@@ -24,7 +24,7 @@ class MerchantApiPubProxy{
         'POST' => [
             'APPLICATION' => '/applications',
             'ACTIVATION' => '/applications/%s/activations',
-            'REFUND' => '/application/%s/refunds',
+            'REFUND' => '/applications/%s/refunds',
             'CANCELLATION' => '/applications/%s/cancellations'
         ],
         'PATCH' => [

--- a/readme.txt
+++ b/readme.txt
@@ -45,6 +45,10 @@ Enable/Disable Automatic Cancellation: Allows you to select if an "Cancellation"
 
  == Changelog ==
 
+Version 2.6.2
+Fix: Amends erroneous refund notification URL path
+Feat: Shorcode widget automatically picks up on the price of a product if shortcode is used on product page
+
 Version 2.6.1
 Fix: Fixes issue with payment method not displaying at checkout when cart threshold is set
 Fix: Fixes duplicated links in backend

--- a/readme.txt
+++ b/readme.txt
@@ -7,8 +7,8 @@ Author URI:        integrations.divido.com
 Author:            Divido Financial Services Ltd
 Requires at least: 3.0.2
 Tested up to:      6.3.1
-Stable tag:        2.6.1
-Version:           2.6.1
+Stable tag:        2.6.2
+Version:           2.6.2
 
 License: GPLv2 or later
 


### PR DESCRIPTION
This PR looks to extend the functionality of our shortcode widget to pick up on the price of a product so that the calculator generated by the widget automatically uses the price of the product (if no default price is given). The shortcode is also beholden to the rules in the plugin config (ie. min product price threshold), so it will not display if it doesn't adhere to the config rules. This is because the primary use for this functionality is to act as a fallback option for any compatibility issues with themers (like Beaver Themer), as was the case [here](https://divido.atlassian.net/browse/SCB-2021), so that merchants can use the shortcode to show the widget if it doesn't display conventionally.

The PR also fixes the path for the refund request endpoint

### PR CHECKLIST

- [ ] All translations are concatenated with an EOT character between the translation context and key (ie. `backend/config[EOT]general_settings_header`)
- [ ] The version information documented in the readme.txt has been manually updated in line with semantic versioning
- [ ] The readme file's Changelog has been updated with your proposed PR
- [ ] The version information in `class-wc-gateway-finance.php` (included within the initial docblock and the start of the constructor) has been updated
