### PR TITLE
fix: adds missing footnote

### DIFF
--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -693,6 +693,10 @@ jQuery(document).ready(function() {
             
             $price = $this->toPence($product->get_price());
 
+            $footnote = (isset($this->footnote) && !empty($this->footnote)) 
+                ? sprintf(' data-footnote="%s"', $this->footnote) 
+                : "";
+
             $language = ($this->useStoreLanguage === "yes") 
                 ? sprintf("data-language='%s'", $this->get_language())
                 : '';

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -694,7 +694,7 @@ jQuery(document).ready(function() {
             $price = $this->toPence($product->get_price());
 
             $footnote = (isset($this->footnote) && !empty($this->footnote)) 
-                ? sprintf(' data-footnote="%s"', $this->footnote) 
+                ? sprintf(' data-footnote="%s"', htmlentities($this->footnote)) 
                 : "";
 
             $language = ($this->useStoreLanguage === "yes") 


### PR DESCRIPTION
Somehow managed to lose the footnote part of the calculator. This fix sends the necessary data attribute to the calculator code, if set in the config panel

### PR CHECKLIST

- [ ] All translations are concatenated with an EOT character between the translation context and key (ie. `backend/config[EOT]general_settings_header`)
- [ ] The version information documented in the readme.txt has been manually updated in line with semantic versioning
- [ ] The readme file's Changelog has been updated with your proposed PR
- [ ] The version information in `class-wc-gateway-finance.php` (included within the initial docblock and the start of the constructor) has been updated
