### PR TITLE
chore: unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ wpcs/
 vendor/
 composer.lock
 .php_cs.cache
+.phpunit.result.cache
+xml-coverage
+coverage.out

--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,8 @@
             "includes/exceptions/ResponseException.php",
             "includes/models/ShortPlan.php"
         ]
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.3"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" bootstrap="tests/bootstrap.php">
+  <testsuites>
+    <testsuite name="unit">
+      <directory suffix="Test.php">tests/unit</directory>
+    </testsuite>
+  </testsuites>
+  <coverage includeUncoveredFiles="true">
+    <report>
+      <text outputFile="coverage.out" showUncoveredFiles="false" showOnlySummary="true"/>
+      <xml outputDirectory="xml-coverage"/>
+  </report>
+  </coverage>
+  <source>
+    <include>
+      <file>class-wc-gateway-finance.php</file>
+      <directory suffix=".php">includes</directory>
+    </include>
+  </source>
+  
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+
+require_once dirname( dirname( __FILE__ ) ) . '/../../../wp-load.php';
+require_once dirname( dirname( __FILE__ ) ) .'/class-wc-gateway-finance.php';

--- a/tests/unit/GatewayTest.php
+++ b/tests/unit/GatewayTest.php
@@ -1,0 +1,19 @@
+<?php 
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class GatewayTest extends TestCase
+{
+    public function setUp():void{
+        $this->gateway = new WC_Gateway_Finance();
+    }
+    
+    public function testConstruct():void{
+        $this->assertSame(
+            'finance',
+            $this->gateway->id
+        );
+    }
+    
+}

--- a/tests/unit/GatewayTest.php
+++ b/tests/unit/GatewayTest.php
@@ -5,6 +5,8 @@ use PHPUnit\Framework\TestCase;
 
 final class GatewayTest extends TestCase
 {
+    private WC_Gateway_Finance $gateway;
+    
     public function setUp():void{
         $this->gateway = new WC_Gateway_Finance();
     }
@@ -15,5 +17,5 @@ final class GatewayTest extends TestCase
             $this->gateway->id
         );
     }
-    
+
 }


### PR DESCRIPTION
Little PR to add a structure to apply rudimentary unit tests for the plugin, using the [make command](https://github.com/dividohq/integrations-woocommerce/commit/eadf777e647ba4be84eebc19817b7e36f93b000a) in the parent development docker environment repo. Needs a bit of refinement, but good for a first pass.

### PR CHECKLIST

- [ ] All translations are concatenated with an EOT character between the translation context and key (ie. `backend/config[EOT]general_settings_header`)
- [ ] The version information documented in the readme.txt has been manually updated in line with semantic versioning
- [ ] The readme file's Changelog has been updated with your proposed PR
- [ ] The version information in `class-wc-gateway-finance.php` (included within the initial docblock and the start of the constructor) has been updated
