### PR TITLE
fix: remove use of mixed

### DIFF
--- a/includes/wrappers/HttpApiWrapper.php
+++ b/includes/wrappers/HttpApiWrapper.php
@@ -47,7 +47,14 @@ class HttpApiWrapper{
         return $response;
     }
 
-    public function post(string $path, mixed $body): array{
+    /**
+     * Wraps the wp_remote_post function
+     *
+     * @param string $path
+     * @param string|array $body
+     * @return array
+     */
+    public function post(string $path, $body): array{
         $args = array_merge($this->defaultArgs, [
             'method' => 'POST',
             'body' => $body
@@ -65,7 +72,14 @@ class HttpApiWrapper{
         return $response;
     }
 
-    public function patch(string $path, mixed $body):array{
+    /**
+     * Wrapper for the wp_remote_post method when used to PATCH
+     *
+     * @param string $path
+     * @param string|array $body
+     * @return array
+     */
+    public function patch(string $path, $body):array{
         $args = array_merge($this->defaultArgs, [
             'method' => 'PATCH',
             'body' => $body


### PR DESCRIPTION
Just a quick rollback on using the `mixed` type, as we still evidently have users on PHP 7.4, so this PHP 8 implementation is causing issues.

### PR CHECKLIST

- [ ] All translations are concatenated with an EOT character between the translation context and key (ie. `backend/config[EOT]general_settings_header`)
- [ ] The version information documented in the readme.txt has been manually updated in line with semantic versioning
- [ ] The readme file's Changelog has been updated with your proposed PR
- [ ] The version information in `class-wc-gateway-finance.php` (included within the initial docblock and the start of the constructor) has been updated
