### PR TITLE
feat: LM2-2240 shipping address

### DIFF
--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -1381,16 +1381,18 @@ jQuery(document).ready(function($) {
                             'lastName' => $order->get_billing_last_name(),
                             'phoneNumber' => str_replace(' ', '', $order->get_billing_phone()),
                             'email' => $order->get_billing_email(),
-                            'addresses' => array([
+                            'addresses' => array(array_filter([
+                                'co' =>  $order->get_billing_company(),
                                 'postcode' => $order->get_billing_postcode(),
                                 'country' => $order->get_billing_country(),
                                 'text' => implode(', ', array_filter([
                                     $order->get_billing_address_2(),
                                     $order->get_billing_address_1(),
-                                    $order->get_billing_city()
+                                    $order->get_billing_city(),
                                 ]))
-                            ]),
-							'shippingAddress' => [
+                            ])),
+							'shippingAddress' => array_filter([
+                                'co' => (empty($order->get_shipping_company())) ? $order->get_billing_company() : $order->get_shipping_company(),
 								'postcode' => (empty($order->get_shipping_postcode())) ? $order->get_billing_postcode() : $order->get_shipping_postcode(),
 								'country' => (empty($order->get_shipping_country())) ? $order->get_billing_country() : $order->get_shipping_country(),
 								'text' => implode(', ', array_filter([
@@ -1398,7 +1400,7 @@ jQuery(document).ready(function($) {
 									(empty($order->get_shipping_address_1())) ? $order->get_billing_address_1() : $order->get_shipping_address_1(),
 									(empty($order->get_shipping_city())) ? $order->get_billing_city() : $order->get_shipping_city()
 								]))
-							]
+							])
                         ]
                     ]
                 )

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -1384,18 +1384,20 @@ jQuery(document).ready(function($) {
                             'addresses' => array([
                                 'postcode' => $order->get_billing_postcode(),
                                 'country' => $order->get_billing_country(),
-                                'text' => implode(' ', [
+                                'text' => implode(', ', array_filter([
+                                    $order->get_billing_address_2(),
                                     $order->get_billing_address_1(),
                                     $order->get_billing_city()
-                                ])
+                                ]))
                             ]),
 							'shippingAddress' => [
 								'postcode' => (empty($order->get_shipping_postcode())) ? $order->get_billing_postcode() : $order->get_shipping_postcode(),
 								'country' => (empty($order->get_shipping_country())) ? $order->get_billing_country() : $order->get_shipping_country(),
-								'text' => implode(' ', [
+								'text' => implode(', ', array_filter([
+									(empty($order->get_shipping_address_2())) ? $order->get_billing_address_2() : $order->get_shipping_address_2(),
 									(empty($order->get_shipping_address_1())) ? $order->get_billing_address_1() : $order->get_shipping_address_1(),
 									(empty($order->get_shipping_city())) ? $order->get_billing_city() : $order->get_shipping_city()
-								])
+								]))
 							]
                         ]
                     ]

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -1370,6 +1370,9 @@ jQuery(document).ready(function($) {
             }
 
             $proxy = new MerchantApiPubProxy($this->url, $this->api_key);
+            
+            preg_match('/^([\d]+)(.+)/', $order->get_shipping_address_1(), $shippingAddress);
+            preg_match('/^([\d]+)(.+)/', $order->get_billing_address_1(), $billingAddress);
 
             $application = (new \Divido\MerchantSDK\Models\Application())
                 ->withCountryId($order->get_billing_country())
@@ -1382,14 +1385,34 @@ jQuery(document).ready(function($) {
                             'phoneNumber' => str_replace(' ', '', $order->get_billing_phone()),
                             'email' => $order->get_billing_email(),
                             'addresses' => array([
+                                'buildingNumber' => $billingAddress[1],
+                                'town' => $order->get_billing_city(),
                                 'postcode' => $order->get_billing_postcode(),
-                                'text' => $order->get_billing_postcode() . ' ' . $order->get_billing_address_1() . ' ' . $order->get_billing_city()
+                                'street' => trim($billingAddress[2]),
+                                'country' => $order->get_billing_country(),
+                                'text' => implode(' ', [
+                                    $order->get_billing_address_1(),
+                                    $order->get_billing_postcode(),
+                                    $order->get_billing_country()
+                                ])
                             ]),
-                        ],
+							'shippingAddress' => [
+								'buildingNumber' => $shippingAddress[1],
+								'postcode' => $order->get_shipping_postcode(),
+								'town' => $order->get_shipping_city(),
+								'street' => trim($shippingAddress[2]),
+								'Country' => $order->get_shipping_country(),
+								'text' => implode(' ', [
+									$order->get_shipping_address_1(),
+									$order->get_shipping_postcode(),
+									$order->get_shipping_country()
+								])
+							]
+                        ]
                     ]
                 )
                 ->withOrderItems($products)
-                ->withDepositAmount((int) $_POST['divido_deposit'])
+                ->withDepositAmount((int) $_POST['divido_deposit'] ?? 0)
                 ->withFinalisationRequired(false)
                 ->withMerchantReference(strval($order_id))
                 ->withUrls([

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -1276,7 +1276,7 @@ jQuery(document).ready(function($) {
             
             $order = new WC_Order($order_id);
             if (
-                !isset($_POST['divido_plan'], $_POST['divido_deposit'], $_POST['submit-payment-form-nonce'])
+                !isset($_POST['divido_plan'], $_POST['submit-payment-form-nonce'])
             ) {
                 throw new \Exception(
                     esc_html_e('frontend/checkout/errordefault_api_error_msg', 'woocommerce-finance-gateway')

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -1370,9 +1370,6 @@ jQuery(document).ready(function($) {
             }
 
             $proxy = new MerchantApiPubProxy($this->url, $this->api_key);
-            
-            preg_match('/^([\d]+)(.+)/', $order->get_shipping_address_1(), $shippingAddress);
-            preg_match('/^([\d]+)(.+)/', $order->get_billing_address_1(), $billingAddress);
 
             $application = (new \Divido\MerchantSDK\Models\Application())
                 ->withCountryId($order->get_billing_country())
@@ -1385,27 +1382,19 @@ jQuery(document).ready(function($) {
                             'phoneNumber' => str_replace(' ', '', $order->get_billing_phone()),
                             'email' => $order->get_billing_email(),
                             'addresses' => array([
-                                'buildingNumber' => $billingAddress[1],
-                                'town' => $order->get_billing_city(),
                                 'postcode' => $order->get_billing_postcode(),
-                                'street' => trim($billingAddress[2]),
                                 'country' => $order->get_billing_country(),
                                 'text' => implode(' ', [
                                     $order->get_billing_address_1(),
-                                    $order->get_billing_postcode(),
-                                    $order->get_billing_country()
+                                    $order->get_billing_city()
                                 ])
                             ]),
 							'shippingAddress' => [
-								'buildingNumber' => $shippingAddress[1],
-								'postcode' => $order->get_shipping_postcode(),
-								'town' => $order->get_shipping_city(),
-								'street' => trim($shippingAddress[2]),
-								'Country' => $order->get_shipping_country(),
+								'postcode' => (empty($order->get_shipping_postcode())) ? $order->get_billing_postcode() : $order->get_shipping_postcode(),
+								'country' => (empty($order->get_shipping_country())) ? $order->get_billing_country() : $order->get_shipping_country(),
 								'text' => implode(' ', [
-									$order->get_shipping_address_1(),
-									$order->get_shipping_postcode(),
-									$order->get_shipping_country()
+									(empty($order->get_shipping_address_1())) ? $order->get_billing_address_1() : $order->get_shipping_address_1(),
+									(empty($order->get_shipping_city())) ? $order->get_billing_city() : $order->get_shipping_city()
 								])
 							]
                         ]


### PR DESCRIPTION
Includes the country for the billing address, and adds a shipping address to the application request. Shipping address reverts to the billing address if not given. Restructures the address format to align with how the information is used in the `applicaiton-api`. This is to obtain compatibility with Oney.

Also removes the requirement for a deposit from the calculator (and assume the deposit is 0), as the calculator seems to be a little reluctant to give us this information these days, if the deposit amount is 0.

### PR CHECKLIST

- [ ] All translations are concatenated with an EOT character between the translation context and key (ie. `backend/config[EOT]general_settings_header`)
- [ ] The version information documented in the readme.txt has been manually updated in line with semantic versioning
- [ ] The readme file's Changelog has been updated with your proposed PR
- [ ] The version information in `class-wc-gateway-finance.php` (included within the initial docblock and the start of the constructor) has been updated
