### PR TITLE
chore: bump to v2.7.2

### DIFF
--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -16,13 +16,13 @@ defined('ABSPATH') or die('Denied');
  * Plugin Name: Finance Payment Gateway for WooCommerce
  * Plugin URI: http://integrations.divido.com/finance-gateway-woocommerce
  * Description: The Finance Payment Gateway plugin for WooCommerce.
- * Version: 2.7.1
+ * Version: 2.7.2
  *
  * Author: Divido Financial Services Ltd
  * Author URI: www.divido.com
  * Text Domain: woocommerce-finance-gateway
  * Domain Path: /i18n/languages/
- * WC tested up to: 8.1.1
+ * WC tested up to: 8.3.1
  */
 
 /**

--- a/class-wc-gateway-finance.php
+++ b/class-wc-gateway-finance.php
@@ -126,7 +126,7 @@ function woocommerce_finance_init()
          */
         function __construct()
         {
-            $this->plugin_version = '2.7.0';
+            $this->plugin_version = '2.7.2';
             add_action('init', array($this, 'wpdocs_load_textdomain'));
 
             $this->id = 'finance';

--- a/readme.txt
+++ b/readme.txt
@@ -6,9 +6,9 @@ Tags:              woothemes,woocommerce,payment gateway,payment,module,ecommerc
 Author URI:        integrations.divido.com
 Author:            Divido Financial Services Ltd
 Requires at least: 3.0.2
-Tested up to:      6.3.2
-Stable tag:        2.7.1
-Version:           2.7.1
+Tested up to:      6.4.1
+Stable tag:        2.7.2
+Version:           2.7.2
 
 License: GPLv2 or later
 
@@ -44,6 +44,9 @@ Enable/Disable Automatic Cancellation: Allows you to select if an "Cancellation"
 
 
  == Changelog ==
+
+Version 2.7.2
+Feat: Adds shipping address to finance application and improves address parsing
 
 Version 2.7.1
 Fix: Rolls back some cosmetic non PHP 7.4 compatible changes


### PR DESCRIPTION
Little bump and readme update for v2.7.2 of the plugin, as is the way with Woocommerce

### PR CHECKLIST

- [ ] All translations are concatenated with an EOT character between the translation context and key (ie. `backend/config[EOT]general_settings_header`)
- [ ] The version information documented in the readme.txt has been manually updated in line with semantic versioning
- [ ] The readme file's Changelog has been updated with your proposed PR
- [ ] The version information in `class-wc-gateway-finance.php` (included within the initial docblock and the start of the constructor) has been updated
