### PR TITLE
feat: extends status triggers

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,4 +3,4 @@
 - [ ] All translations are concatenated with an EOT character between the translation context and key (ie. `backend/config[EOT]general_settings_header`)
 - [ ] The version information documented in the readme.txt has been manually updated in line with semantic versioning
 - [ ] The readme file's Changelog has been updated with your proposed PR
-- [ ] The version information in `class-wc-gateway-finance.php` (included within the initial docblock and the start of the constructor) has been updated
+- [ ] The version information in `includes/class-wc-gateway-finance.php` (at the start of the constructor) and `woocommerce-gateway-finance.php` (included within the initial docblock) has been updated

--- a/includes/class-wc-gateway-finance.php
+++ b/includes/class-wc-gateway-finance.php
@@ -560,18 +560,6 @@ jQuery(document).ready(function() {
                         } else {
                             // Amount matches, update status.
 
-<<<<<<< HEAD:includes/class-wc-gateway-finance.php
-                            if ('DECLINED' === $data_json->status) {
-                                $order->update_status('failed');
-                                $this->send_json();
-                            } elseif ('SIGNED' === $data_json->status) {
-                                $order->update_status('processing', $data_json->application);
-                                $this->send_json();
-                            } elseif ('READY' === $data_json->status) {
-                                $order->add_order_note('Finance status: ' . $data_json->status);
-                                $order->payment_complete();
-                                $this->send_json();
-=======
                             switch($data_json->status){
                                 case self::STATUS_DECLINED:
                                     $order->update_status('failed');
@@ -596,7 +584,6 @@ jQuery(document).ready(function() {
                                     $order->update_status('pending-payment');
                                     $this->send_json();
                                     break;
->>>>>>> 1c7fee6 (feat: extends status triggers):class-wc-gateway-finance.php
                             }
                         }
                         // Log status to order.

--- a/includes/class-wc-gateway-finance.php
+++ b/includes/class-wc-gateway-finance.php
@@ -91,6 +91,19 @@ function woocommerce_finance_init()
         const REFUND_ACTION = 'refund';
         const CANCEL_ACTION = 'cancel';
 
+        const 
+            STATUS_ACCEPTED = 'ACCEPTED',
+            STATUS_ACTION_LENDER = 'ACTION-LENDER',
+            STATUS_CANCELED = 'CANCELED',
+            STATUS_COMPLETED = 'COMPLETED',
+            STATUS_DECLINED = 'DECLINED',
+            STATUS_DEPOSIT_PAID = 'DEPOSIT-PAID',
+            STATUS_AWAITING_ACTIVATION = 'AWAITING-ACTIVATION',
+            STATUS_FULFILLED = 'FULFILLED',
+            STATUS_REFERRED = 'REFERRED',
+            STATUS_SIGNED = 'SIGNED',
+            STATUS_READY = 'READY';
+
         function wpdocs_load_textdomain()
         {
             if (!load_plugin_textdomain(
@@ -547,6 +560,7 @@ jQuery(document).ready(function() {
                         } else {
                             // Amount matches, update status.
 
+<<<<<<< HEAD:includes/class-wc-gateway-finance.php
                             if ('DECLINED' === $data_json->status) {
                                 $order->update_status('failed');
                                 $this->send_json();
@@ -557,6 +571,32 @@ jQuery(document).ready(function() {
                                 $order->add_order_note('Finance status: ' . $data_json->status);
                                 $order->payment_complete();
                                 $this->send_json();
+=======
+                            switch($data_json->status){
+                                case self::STATUS_DECLINED:
+                                    $order->update_status('failed');
+                                    $this->send_json();
+                                    break;
+                                case self::STATUS_SIGNED:
+                                    $order->update_status('processing');
+                                    $this->send_json();
+                                    break;
+                                case self::STATUS_READY:
+                                    $order->add_order_note('Finance status: ' . $data_json->status);
+                                    $order->payment_complete();
+                                    $this->send_json();
+                                    break;
+                                case self::STATUS_REFERRED:
+                                    $order->add_order_note('Finance status: ' . $data_json->status);
+                                    $order->update_status('on-hold');
+                                    $this->send_json();
+                                    break;
+                                case self::STATUS_ACCEPTED:
+                                    $order->add_order_note('Finance status: ' . $data_json->status);
+                                    $order->update_status('pending-payment');
+                                    $this->send_json();
+                                    break;
+>>>>>>> 1c7fee6 (feat: extends status triggers):class-wc-gateway-finance.php
                             }
                         }
                         // Log status to order.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce-gateway-finance",
 	"title": "WooCommerce Finance Payments",
-	"version": "0.0.1",
+	"version": "2.8.2",
 	"author": "Divido",
 	"license": "GPL-3.0+",
 	"keywords": [],

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags:              woothemes,woocommerce,payment gateway,payment,module,ecommerc
 Author URI:        integrations.divido.com
 Author:            Divido Financial Services Ltd
 Requires at least: 3.0.2
-Tested up to:      6.4.3
+Tested up to:      6.5.2
 Stable tag:        2.8.2
 Version:           2.8.2
 
@@ -45,7 +45,7 @@ Shortcode Calculator widget to display finance options ad-hoc
 
  == Changelog ==
 
- Version 2.8.2
+Version 2.8.2
 Chore: add x-divido-version header
 
 Version 2.8.1

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,4 @@
 <?php
 
 require_once dirname( dirname( __FILE__ ) ) . '/../../../wp-load.php';
-require_once dirname( dirname( __FILE__ ) ) .'/class-wc-gateway-finance.php';
+require_once dirname( dirname( __FILE__ ) ) .'/includes/class-wc-gateway-finance.php';

--- a/tests/unit/GatewayTest.php
+++ b/tests/unit/GatewayTest.php
@@ -13,7 +13,7 @@ final class GatewayTest extends TestCase
     
     public function testConstruct():void{
         $this->assertSame(
-            'finance',
+            'divido-finance',
             $this->gateway->id
         );
     }

--- a/woocommerce-gateway-finance.php
+++ b/woocommerce-gateway-finance.php
@@ -14,7 +14,7 @@
  * Author URI: www.divido.com
  * Text Domain: woocommerce-finance-gateway
  * Domain Path: /i18n/languages/
- * WC tested up to: 8.6.1
+ * WC tested up to: 8.8.2
  *
  */
 

--- a/woocommerce-gateway-finance.php
+++ b/woocommerce-gateway-finance.php
@@ -8,7 +8,7 @@
  * Plugin Name: Finance Payment Gateway for WooCommerce
  * Plugin URI: http://integrations.divido.com/finance-gateway-woocommerce
  * Description: The Finance Payment Gateway plugin for WooCommerce.
- * Version: 2.8.1
+ * Version: 2.8.2
  *
  * Author: Divido Financial Services Ltd
  * Author URI: www.divido.com


### PR DESCRIPTION
Small change for Woocommerce to notify merchants when an order has been referred, changing the status of the order to `on-hold` when the store receives the `REFERRED` webhook from us, then transitioning it to `pending-payment` when the store receives an `ACCEPTED` webhook.

Also uses consts and switches, because I'm fancy like that.

Ed: Using this PR to bump the version and administer a bit of upkeep too.

### PR CHECKLIST

- [ ] All translations are concatenated with an EOT character between the translation context and key (ie. `backend/config[EOT]general_settings_header`)
- [ ] The version information documented in the readme.txt has been manually updated in line with semantic versioning
- [ ] The readme file's Changelog has been updated with your proposed PR
- [ ] The version information in `class-wc-gateway-finance.php` (included within the initial docblock and the start of the constructor) has been updated
