### PR TITLE
fix: divido version header

### DIFF
--- a/includes/proxies/MerchantApiPubProxy.php
+++ b/includes/proxies/MerchantApiPubProxy.php
@@ -66,7 +66,7 @@ class MerchantApiPubProxy{
         $this->wrapper->setHeader('Accept', 'application/json');
         $this->wrapper->setHeader('Content-Type', 'application/json');
         $this->wrapper->setHeader(self::HEADER_KEYS['API_KEY'], $apiKey);
-         $this->wrapper->setHeader(self::HEADER_KEYS['VERSION'], VERSION);
+        $this->wrapper->setHeader(self::HEADER_KEYS['VERSION'], self::VERSION);
     }
 
     /**

--- a/includes/proxies/MerchantApiPubProxy.php
+++ b/includes/proxies/MerchantApiPubProxy.php
@@ -57,7 +57,7 @@ class MerchantApiPubProxy{
         'VERSION' => 'X-DIVIDO-VERSION',
     ];
 
-    const VERSION = '2'
+    const VERSION = '2';
 
     private HttpApiWrapper $wrapper;
 


### PR DESCRIPTION
Fixes a few oopsies in the previous PR. Ideally we need the API Key to inform the plugin which version to send in the header, but that's a task for another day, I guess.

### PR CHECKLIST

- [ ] All translations are concatenated with an EOT character between the translation context and key (ie. `backend/config[EOT]general_settings_header`)
- [ ] The version information documented in the readme.txt has been manually updated in line with semantic versioning
- [ ] The readme file's Changelog has been updated with your proposed PR
- [ ] The version information in `class-wc-gateway-finance.php` (included within the initial docblock and the start of the constructor) has been updated
